### PR TITLE
Add billing settings tab + batch approve for techs

### DIFF
--- a/apps/customer_portal/forms.py
+++ b/apps/customer_portal/forms.py
@@ -46,6 +46,11 @@ class RepairPreferenceForm(forms.ModelForm):
             'lot_walking_enabled',
             'lot_walking_frequency',
             'lot_walking_time',
+            # Billing & Invoicing
+            'invoice_preference',
+            'billing_email',
+            'auto_email_invoices',
+            'include_photos_in_invoice',
         ]
 
         # Customize how fields appear in the form
@@ -60,6 +65,11 @@ class RepairPreferenceForm(forms.ModelForm):
                 'class': 'form-control',
                 'type': 'time'
             }),
+            'invoice_preference': forms.RadioSelect(),
+            'billing_email': forms.EmailInput(attrs={
+                'class': 'form-control',
+                'placeholder': 'billing@yourcompany.com'
+            }),
         }
 
         # Custom labels (what users see)
@@ -69,6 +79,10 @@ class RepairPreferenceForm(forms.ModelForm):
             'lot_walking_enabled': 'Enable Lot Walking Service',
             'lot_walking_frequency': 'Lot Walking Frequency',
             'lot_walking_time': 'Preferred Time',
+            'invoice_preference': 'Invoice Generation Mode',
+            'billing_email': 'Billing Email Address',
+            'auto_email_invoices': 'Automatically Email Invoices',
+            'include_photos_in_invoice': 'Include Photos in Invoices',
         }
 
     def __init__(self, *args, **kwargs):

--- a/apps/technician_portal/urls.py
+++ b/apps/technician_portal/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('repairs/<int:repair_id>/update/', views.update_repair, name='update_repair'),
     path('repairs/<int:repair_id>/update-status/', views.update_queue_status, name='update_queue_status'),
     path('check-existing-repair/', views.check_existing_repair, name='check_existing_repair'),
+    path('repairs/bulk-action/', views.bulk_repair_action, name='tech_bulk_repair_action'),
     path('api/batch-pricing/', views.get_batch_pricing_json, name='get_batch_pricing'),
     path('api/viscosity-suggestion/', views.get_viscosity_suggestion, name='get_viscosity_suggestion'),
 

--- a/apps/technician_portal/views/__init__.py
+++ b/apps/technician_portal/views/__init__.py
@@ -25,6 +25,7 @@ from .repairs import (
     assign_repair,
     reassign_to_self,
     check_existing_repair,
+    bulk_repair_action,
 )
 
 # Multi-break batch operations

--- a/apps/technician_portal/views/repairs.py
+++ b/apps/technician_portal/views/repairs.py
@@ -5,6 +5,7 @@ Repair CRUD, list, detail, and status management views.
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib import messages
 from django.utils import timezone
+from django.db import transaction
 from django.db.models import Q
 from django.http import JsonResponse
 from django.core.paginator import Paginator
@@ -723,3 +724,126 @@ def check_existing_repair(request):
             'warning_message': f"There is already a {existing_repair.get_queue_status_display()} repair for this unit."
         })
     return JsonResponse({'existing_repair': False})
+
+
+@technician_required
+def bulk_repair_action(request):
+    """Handle bulk approve or deny actions for multiple repairs (technician/manager)."""
+    if request.method != 'POST':
+        messages.error(request, "Invalid request method.")
+        return redirect('repair_list')
+
+    if not hasattr(request.user, 'technician'):
+        messages.error(request, "You don't have a technician profile.")
+        return redirect('technician_dashboard')
+
+    technician = request.user.technician
+    is_admin = is_tenant_admin(request.user)
+
+    # Only managers and admins can bulk-approve
+    if not is_admin and not technician.is_manager:
+        messages.error(request, "Only managers can perform bulk actions on repairs.")
+        return redirect('repair_list')
+
+    action = request.POST.get('action')
+    if action not in ['approve', 'deny']:
+        messages.error(request, "Invalid action specified.")
+        return redirect('repair_list')
+
+    repair_ids = request.POST.getlist('repair_ids')
+    if not repair_ids:
+        messages.error(request, "No repairs selected.")
+        return redirect('repair_list')
+
+    tenant = getattr(request, 'tenant', None)
+
+    with transaction.atomic():
+        # Get repairs that are PENDING or REQUESTED
+        repairs = Repair.objects.filter(
+            id__in=repair_ids,
+            queue_status__in=['PENDING', 'REQUESTED']
+        ).select_related('customer', 'technician')
+
+        if tenant:
+            repairs = repairs.filter(tenant=tenant)
+
+        if not repairs.exists():
+            messages.error(request, "No valid repairs found to process.")
+            return redirect('repair_list')
+
+        processed_count = 0
+
+        for repair in repairs:
+            if action == 'approve':
+                # For REQUESTED repairs, assign to the acting technician
+                if repair.queue_status == 'REQUESTED' and not repair.technician:
+                    repair.technician = technician
+
+                repair.queue_status = 'APPROVED'
+                repair.save()
+
+                # Create approval record
+                customer_users = CustomerUser.objects.filter(customer=repair.customer)
+                customer_user = customer_users.filter(is_primary_contact=True).first()
+                if not customer_user and customer_users.exists():
+                    customer_user = customer_users.first()
+
+                if customer_user:
+                    RepairApproval.objects.update_or_create(
+                        repair=repair,
+                        defaults={
+                            'approved': True,
+                            'approved_by': customer_user,
+                            'approval_date': timezone.now(),
+                            'notes': f'Bulk approved by technician {technician.user.get_full_name()}'
+                        }
+                    )
+
+                # Notify assigned technician if different from actor
+                if repair.technician and repair.technician != technician:
+                    TechnicianNotification.objects.create(
+                        technician=repair.technician,
+                        message=f"✅ Repair #{repair.id} for {repair.customer.name} - Unit {repair.unit_number} has been approved.",
+                        read=False,
+                        repair=repair
+                    )
+
+            else:  # deny
+                repair.queue_status = 'DENIED'
+                repair.save()
+
+                # Create denial record
+                customer_users = CustomerUser.objects.filter(customer=repair.customer)
+                customer_user = customer_users.filter(is_primary_contact=True).first()
+                if not customer_user and customer_users.exists():
+                    customer_user = customer_users.first()
+
+                if customer_user:
+                    RepairApproval.objects.update_or_create(
+                        repair=repair,
+                        defaults={
+                            'approved': False,
+                            'approved_by': customer_user,
+                            'approval_date': timezone.now(),
+                            'notes': f'Bulk denied by technician {technician.user.get_full_name()}'
+                        }
+                    )
+
+                # Notify assigned technician if different from actor
+                if repair.technician and repair.technician != technician:
+                    TechnicianNotification.objects.create(
+                        technician=repair.technician,
+                        message=f"❌ Repair #{repair.id} for {repair.customer.name} - Unit {repair.unit_number} has been denied.",
+                        read=False,
+                        repair=repair
+                    )
+
+            processed_count += 1
+
+        action_word = "approved" if action == 'approve' else "denied"
+        messages.success(
+            request,
+            f"Successfully {action_word} {processed_count} repair{'' if processed_count == 1 else 's'}."
+        )
+
+    return redirect('repair_list')

--- a/templates/customer_portal/account_settings.html
+++ b/templates/customer_portal/account_settings.html
@@ -224,6 +224,10 @@
                         <i class="fas fa-shield-alt"></i>
                         <span>Security</span>
                     </button>
+                    <button type="button" class="tab-button" data-tab="billing">
+                        <i class="fas fa-file-invoice-dollar"></i>
+                        <span>Billing & Invoicing</span>
+                    </button>
                 </div>
             </div>
 
@@ -539,6 +543,119 @@
                                     Confirm New Password
                                 </label>
                                 <input type="password" class="form-input" id="confirm_password" name="confirm_password" placeholder="Re-enter your new password">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Billing & Invoicing Tab -->
+                <div class="tab-content p-6" id="billing-tab" style="display: none;">
+                    <!-- Invoice Preference Card -->
+                    <div class="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+                        <div class="flex items-center justify-between mb-6">
+                            <div class="flex items-center gap-3">
+                                <div class="bg-purple-100 text-purple-600 p-2 rounded-lg">
+                                    <i class="fas fa-file-invoice-dollar text-xl"></i>
+                                </div>
+                                <div>
+                                    <h3 class="text-lg font-semibold text-gray-900 flex items-center gap-2">
+                                        Invoice Generation Mode
+                                        <span class="tooltip-trigger">
+                                            <i class="fas fa-circle-question text-sm"></i>
+                                            <span class="tooltip-content">
+                                                Choose how and when invoices are generated for your repairs
+                                            </span>
+                                        </span>
+                                    </h3>
+                                    <p class="text-sm text-gray-600">Configure how invoices are created for completed repairs</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="radio-group">
+                            {% for radio in repair_form.invoice_preference %}
+                            <label class="radio-option">
+                                {{ radio.tag }}
+                                <div class="flex-1">
+                                    <div class="font-medium text-gray-900">
+                                        {% if radio.value == 'per_ticket' %}
+                                        Per Repair
+                                        {% elif radio.value == 'batch' %}
+                                        Batch Invoicing
+                                        {% elif radio.value == 'manual' %}
+                                        Manual Only
+                                        {% else %}
+                                        {{ radio.choice_label }}
+                                        {% endif %}
+                                    </div>
+                                    <div class="text-sm text-gray-600 mt-1">
+                                        {% if radio.value == 'per_ticket' %}
+                                        An invoice is automatically generated each time a repair is completed
+                                        {% elif radio.value == 'batch' %}
+                                        Repairs are grouped together and invoiced periodically (recommended for high-volume accounts)
+                                        {% elif radio.value == 'manual' %}
+                                        Invoices are only created when manually requested — no automatic generation
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </label>
+                            {% endfor %}
+                        </div>
+                    </div>
+
+                    <!-- Email & Delivery Settings Card -->
+                    <div class="bg-white border border-gray-200 rounded-lg p-6">
+                        <div class="flex items-center justify-between mb-6">
+                            <div class="flex items-center gap-3">
+                                <div class="bg-blue-100 text-blue-600 p-2 rounded-lg">
+                                    <i class="fas fa-envelope text-xl"></i>
+                                </div>
+                                <div>
+                                    <h3 class="text-lg font-semibold text-gray-900">Email & Delivery Settings</h3>
+                                    <p class="text-sm text-gray-600">Configure how invoices are delivered to your team</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Billing Email -->
+                        <div class="form-group">
+                            <label for="{{ repair_form.billing_email.id_for_label }}" class="form-label">
+                                <i class="fas fa-at text-gray-400"></i>
+                                Billing Email Address
+                                <span class="tooltip-trigger">
+                                    <i class="fas fa-circle-question text-sm"></i>
+                                    <span class="tooltip-content">
+                                        Invoices will be sent to this address. Leave blank to use your account email.
+                                    </span>
+                                </span>
+                            </label>
+                            <input type="email" class="form-input max-w-md" id="{{ repair_form.billing_email.id_for_label }}" name="{{ repair_form.billing_email.name }}" value="{{ repair_form.billing_email.value|default:'' }}" placeholder="billing@yourcompany.com">
+                            <p class="text-xs text-gray-500 mt-1">Leave blank to use your primary account email</p>
+                        </div>
+
+                        <!-- Auto Email Toggle -->
+                        <div class="flex items-start gap-3 p-4 bg-gray-50 rounded-lg mb-4">
+                            <div class="flex items-center h-5">
+                                <input type="checkbox" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" id="{{ repair_form.auto_email_invoices.id_for_label }}" name="{{ repair_form.auto_email_invoices.name }}" {% if repair_form.auto_email_invoices.value %}checked{% endif %}>
+                            </div>
+                            <div class="flex-1">
+                                <label for="{{ repair_form.auto_email_invoices.id_for_label }}" class="text-sm font-medium text-gray-900 cursor-pointer">
+                                    Automatically Email Invoices
+                                </label>
+                                <p class="text-xs text-gray-600 mt-1">When enabled, invoices are automatically emailed as soon as they are generated</p>
+                            </div>
+                        </div>
+
+                        <!-- Include Photos Toggle -->
+                        <div class="flex items-start gap-3 p-4 bg-gray-50 rounded-lg">
+                            <div class="flex items-center h-5">
+                                <input type="checkbox" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" id="{{ repair_form.include_photos_in_invoice.id_for_label }}" name="{{ repair_form.include_photos_in_invoice.name }}" {% if repair_form.include_photos_in_invoice.value %}checked{% endif %}>
+                            </div>
+                            <div class="flex-1">
+                                <label for="{{ repair_form.include_photos_in_invoice.id_for_label }}" class="text-sm font-medium text-gray-900 cursor-pointer">
+                                    Include Repair Photos in Invoices
+                                </label>
+                                <p class="text-xs text-gray-600 mt-1">Attach before/after repair photos to invoice emails for documentation purposes</p>
                             </div>
                         </div>
                     </div>

--- a/templates/technician_portal/repair_list.html
+++ b/templates/technician_portal/repair_list.html
@@ -77,6 +77,39 @@
 {% block content %}
 <div class="min-h-screen bg-gray-50">
     <div class="max-w-full px-4 sm:px-6 lg:px-8 py-8">
+        <!-- Bulk Action Toolbar (Hidden by default, shown via JavaScript) -->
+        <div id="bulk-toolbar" class="hidden fixed bottom-0 left-0 right-0 bg-green-600 shadow-lg border-t-4 border-green-700 z-50 transition-all">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center space-x-4">
+                        <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                        <span class="text-white font-medium">
+                            <span id="selected-count">0</span> repair<span id="plural-s">s</span> selected
+                        </span>
+                    </div>
+                    <div class="flex items-center space-x-3">
+                        <button onclick="bulkApprove()" class="inline-flex items-center px-6 py-2.5 bg-white text-green-700 font-medium rounded-lg hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors shadow-md">
+                            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                            </svg>
+                            Approve Selected (<span id="approve-count">0</span>)
+                        </button>
+                        <button onclick="bulkDeny()" class="inline-flex items-center px-6 py-2.5 bg-red-600 text-white font-medium rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors shadow-md">
+                            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                            </svg>
+                            Deny Selected (<span id="deny-count">0</span>)
+                        </button>
+                        <button onclick="deselectAll()" class="inline-flex items-center px-4 py-2.5 bg-green-500 text-white font-medium rounded-lg hover:bg-green-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors">
+                            Deselect All
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Page Header -->
         <div class="mb-6">
             <div class="flex items-center justify-between">
@@ -372,6 +405,9 @@
                     <table class="min-w-full divide-y divide-gray-200">
                         <thead class="bg-gray-50 sticky-header">
                             <tr>
+                                <th scope="col" class="px-4 py-3 text-left">
+                                    <input type="checkbox" id="select-all" onclick="toggleSelectAll(this)" class="w-4 h-4 text-green-600 border-gray-300 rounded focus:ring-green-500" title="Select all pending/requested repairs">
+                                </th>
                                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     ID
                                 </th>
@@ -409,6 +445,13 @@
                         <tbody class="bg-white divide-y divide-gray-200">
                             {% for repair in repairs %}
                             <tr class="table-row {% if repair.queue_status == 'REQUESTED' %}bg-yellow-50{% endif %}">
+                                <td class="px-4 py-4 whitespace-nowrap">
+                                    {% if repair.queue_status == 'PENDING' or repair.queue_status == 'REQUESTED' %}
+                                    <input type="checkbox" class="repair-checkbox w-4 h-4 text-green-600 border-gray-300 rounded focus:ring-green-500" data-repair-id="{{ repair.id }}" onchange="updateBulkToolbar()">
+                                    {% else %}
+                                    <span class="text-gray-300">—</span>
+                                    {% endif %}
+                                </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                                     #{{ repair.id }}
                                     {% if repair.repair_batch_id %}
@@ -491,7 +534,7 @@
                             </tr>
                             {% empty %}
                             <tr>
-                                <td colspan="{% if is_admin %}10{% else %}9{% endif %}" class="px-6 py-12 text-center">
+                                <td colspan="{% if is_admin %}11{% else %}10{% endif %}" class="px-6 py-12 text-center">
                                     <div class="text-gray-500">
                                         <svg class="mx-auto h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
@@ -623,6 +666,110 @@ function changeSort(sortBy) {
     url.searchParams.set('sort', sortBy);
     url.searchParams.set('page', '1'); // Reset to first page
     window.location.href = url.toString();
+}
+
+// Bulk selection management
+function toggleSelectAll(checkbox) {
+    const checkboxes = document.querySelectorAll('.repair-checkbox');
+    checkboxes.forEach(cb => {
+        cb.checked = checkbox.checked;
+    });
+    updateBulkToolbar();
+}
+
+function updateBulkToolbar() {
+    const checkboxes = document.querySelectorAll('.repair-checkbox:checked');
+    const count = checkboxes.length;
+    const toolbar = document.getElementById('bulk-toolbar');
+
+    if (count > 0) {
+        toolbar.classList.remove('hidden');
+        document.getElementById('selected-count').textContent = count;
+        document.getElementById('approve-count').textContent = count;
+        document.getElementById('deny-count').textContent = count;
+        document.getElementById('plural-s').textContent = count === 1 ? '' : 's';
+    } else {
+        toolbar.classList.add('hidden');
+    }
+
+    // Update select-all checkbox state
+    const allCheckboxes = document.querySelectorAll('.repair-checkbox');
+    const selectAllCheckbox = document.getElementById('select-all');
+    if (selectAllCheckbox) {
+        selectAllCheckbox.checked = allCheckboxes.length > 0 && count === allCheckboxes.length;
+        selectAllCheckbox.indeterminate = count > 0 && count < allCheckboxes.length;
+    }
+}
+
+function deselectAll() {
+    const checkboxes = document.querySelectorAll('.repair-checkbox');
+    checkboxes.forEach(cb => {
+        cb.checked = false;
+    });
+    document.getElementById('select-all').checked = false;
+    updateBulkToolbar();
+}
+
+function getSelectedRepairIds() {
+    const repairIds = [];
+    const checkboxes = document.querySelectorAll('.repair-checkbox:checked');
+    checkboxes.forEach(cb => {
+        if (cb.dataset.repairId) {
+            repairIds.push(cb.dataset.repairId);
+        }
+    });
+    return repairIds;
+}
+
+function bulkApprove() {
+    const repairIds = getSelectedRepairIds();
+    if (repairIds.length === 0) return;
+
+    if (confirm(`Are you sure you want to approve ${repairIds.length} repair${repairIds.length === 1 ? '' : 's'}?`)) {
+        submitBulkAction('approve', repairIds);
+    }
+}
+
+function bulkDeny() {
+    const repairIds = getSelectedRepairIds();
+    if (repairIds.length === 0) return;
+
+    if (confirm(`Are you sure you want to deny ${repairIds.length} repair${repairIds.length === 1 ? '' : 's'}?`)) {
+        submitBulkAction('deny', repairIds);
+    }
+}
+
+function submitBulkAction(action, repairIds) {
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = '{% url "tech_bulk_repair_action" %}';
+
+    // Add CSRF token
+    const csrfToken = '{{ csrf_token }}';
+    const csrfInput = document.createElement('input');
+    csrfInput.type = 'hidden';
+    csrfInput.name = 'csrfmiddlewaretoken';
+    csrfInput.value = csrfToken;
+    form.appendChild(csrfInput);
+
+    // Add action
+    const actionInput = document.createElement('input');
+    actionInput.type = 'hidden';
+    actionInput.name = 'action';
+    actionInput.value = action;
+    form.appendChild(actionInput);
+
+    // Add repair IDs
+    repairIds.forEach(id => {
+        const idInput = document.createElement('input');
+        idInput.type = 'hidden';
+        idInput.name = 'repair_ids';
+        idInput.value = id;
+        form.appendChild(idInput);
+    });
+
+    document.body.appendChild(form);
+    form.submit();
 }
 
 // Export to CSV


### PR DESCRIPTION
## Changes

### 1. Billing & Invoicing Tab — Customer Account Settings
- Added invoice preference, billing email, auto-email, and include-photos fields to the RepairPreferenceForm
- New 4th tab on account settings page matching existing style
- Radio buttons for invoice mode (per repair / batch / manual)
- Toggles for auto-email and photo inclusion
- Unlocks the existing auto-invoice backend that fires on repair completion

### 2. Batch Approve/Deny for Technicians
- Checkboxes on PENDING/REQUESTED repairs in tech repair list
- Select all checkbox in table header
- Fixed bottom toolbar with Approve Selected / Deny Selected buttons
- Manager/admin permission required
- Transaction safe with approval records and notifications
- New endpoint: `/tech/repairs/bulk-action/`

### 3. Customer Batch Approve (already existed)
- Confirmed customer portal already has checkbox-based bulk approve/deny

**Tests:** 18 passing (permissions, templates, signup)
**Files changed:** 6 files, +405 lines