### PR TITLE
fix: guard batch_id None crash + add reportlab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,8 @@ flower==2.0.1
 # Payments
 stripe>=8.0.0
 
+# PDF generation
+reportlab>=4.0.0
+
 # Error tracking and monitoring
 sentry-sdk==1.40.0 

--- a/templates/technician_portal/dashboard.html
+++ b/templates/technician_portal/dashboard.html
@@ -336,9 +336,11 @@
                                     {% endfor %}
                                 </div>
                             </div>
+                            {% if batch.batch_id %}
                             <a href="{% url 'technician_batch_detail' batch.batch_id %}" class="flex-shrink-0 inline-flex items-center px-3 py-2 bg-orange-600 text-white text-xs font-medium rounded hover:bg-orange-700 transition-colors">
                                 Continue
                             </a>
+                            {% endif %}
                         </div>
                     </div>
                     {% endfor %}
@@ -393,6 +395,7 @@
                                     {% endfor %}
                                 </div>
                             </div>
+                            {% if batch.batch_id %}
                             <div class="flex-shrink-0 flex flex-col gap-1">
                                 <form action="{% url 'technician_batch_start_work' batch.batch_id %}" method="post" class="inline">
                                     {% csrf_token %}
@@ -404,6 +407,7 @@
                                     Details
                                 </a>
                             </div>
+                            {% endif %}
                         </div>
                     </div>
                     {% endfor %}


### PR DESCRIPTION
## What
- Dashboard template crashes with `NoReverseMatch` when `batch.batch_id` is None
- Invoice PDF generation fails because `reportlab` isn't in requirements.txt

## Fix
- Wrapped `{% url 'technician_batch_detail' batch.batch_id %}` calls in `{% if batch.batch_id %}` guards (lines 339, 397-405)
- Added `reportlab>=4.0.0` to requirements.txt

## Testing
- Null batch_id no longer crashes the page — buttons just don't render
- reportlab will install on next `eb deploy`