### PR TITLE
fix: add billing logger to production so auto-invoice errors are visible

### DIFF
--- a/rs_systems/settings/production.py
+++ b/rs_systems/settings/production.py
@@ -232,6 +232,11 @@ LOGGING = {
             'level': 'INFO',
             'propagate': False,
         },
+        'apps.billing': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': False,
+        },
     },
 }
 


### PR DESCRIPTION
Billing signal catches all exceptions and logs them, but prod logging config only showed ERROR for django and INFO for celery. Added `apps.billing` logger at INFO level.

After deploying this, complete a repair and check `eb logs | grep billing` — you'll see exactly what the auto-invoice service is doing (or failing on).