### PR TITLE
fix: invoice email fails — wrong import path for InvoiceService

### DIFF
--- a/apps/billing/services/invoice_email_service.py
+++ b/apps/billing/services/invoice_email_service.py
@@ -21,7 +21,7 @@ from django.conf import settings
 from django.core.mail import EmailMessage
 from django.utils import timezone
 
-from apps.clawdbot.services.invoice_service import InvoiceService, InvoiceData
+from apps.billing.services.invoice_service import InvoiceService, InvoiceData
 from apps.technician_portal.models import Repair
 
 

--- a/apps/billing/services/invoice_storage_service.py
+++ b/apps/billing/services/invoice_storage_service.py
@@ -20,7 +20,7 @@ import boto3
 from botocore.exceptions import ClientError
 from django.utils import timezone
 
-from apps.clawdbot.services.invoice_service import InvoiceData
+from apps.billing.services.invoice_service import InvoiceData
 
 
 # S3 path structure: invoices/{customer_id}/{year}/{invoice_number}.pdf


### PR DESCRIPTION
Invoice PDF generates and saves to S3 fine, but email step fails:
```
Could not check/send email for invoice: No module named 'apps.clawdbot.services.invoice_service'
```

Two files were importing `InvoiceService` from `apps.clawdbot.services` instead of `apps.billing.services` where it actually lives.

Fixed:
- `apps/billing/services/invoice_email_service.py`
- `apps/billing/services/invoice_storage_service.py`