### PR TITLE
fix: invoice email crash — shadowed os import

### DIFF
--- a/apps/billing/services/invoice_email_service.py
+++ b/apps/billing/services/invoice_email_service.py
@@ -266,7 +266,6 @@ class InvoiceEmailService:
             # Save invoice locally for record keeping
             # (S3 saving requires write permissions - not available yet)
             try:
-                import os
                 invoice_dir = f"/home/ubuntu/invoices/{customer_id}"
                 os.makedirs(invoice_dir, exist_ok=True)
                 local_path = f"{invoice_dir}/{invoice_data.invoice_number}.pdf"


### PR DESCRIPTION
Local `import os` inside a try block shadowed the module-level import, causing:
```
cannot access local variable 'os' where it is not associated with a value
```
Removed the redundant import. Module-level `import os` at line 14 handles it.