### PR TITLE
fix: Stripe payment link missing from emails + logo not loading on EB

### DIFF
--- a/BILLING_ROADMAP.md
+++ b/BILLING_ROADMAP.md
@@ -172,3 +172,27 @@
 - **Reminder frequency**: How aggressive? (e.g., 7 days, then weekly?)
 - **Batch invoicing**: For fleet customers, weekly or monthly consolidation?
 - **Per-customer payment terms**: Need override per customer, or global default enough for now?
+
+---
+
+## Phase 7: SaaS Subscription Billing (Glass Shops)
+
+Separate from customer billing — this is charging glass shops to use RS Systems.
+
+**Already built:**
+- SubscriptionPlan model (Trial/Starter $49/Pro $99/Enterprise $249)
+- Plan limits (repairs/month, technicians, customers, storage)
+- Feature flags per plan
+- SubscriptionService + signup flow
+- Owner billing page at `/owner/billing/`
+- Tenant webhook handler
+
+**Still needed:**
+- [ ] Create Stripe Products + Prices in Stripe Dashboard
+- [ ] Copy `stripe_price_id` / `stripe_annual_price_id` into SubscriptionPlan records
+- [ ] Wire up subscription checkout flow (owner upgrades/downgrades plan)
+- [ ] Handle subscription webhooks (invoice.paid, customer.subscription.updated/deleted)
+- [ ] Dunning — handle failed subscription payments gracefully
+- [ ] Usage enforcement — block actions when plan limits hit (repairs, techs, storage)
+- [ ] Trial expiration → prompt to upgrade
+- [ ] Billing portal link (Stripe Customer Portal for managing payment method/invoices)

--- a/apps/billing/services/invoice_email_service.py
+++ b/apps/billing/services/invoice_email_service.py
@@ -224,11 +224,6 @@ class InvoiceEmailService:
             Tuple of (success: bool, message: str)
         """
         try:
-            # Set logo path
-            logo_path = '/home/ubuntu/rswr_systems/media/email_branding/logo_02_jpg-01_copy_optimized.jpg'
-            if os.path.exists(logo_path):
-                self.invoice_service.logo_path = logo_path
-            
             # Generate invoice
             start_date = timezone.now() - timedelta(days=days) if not repair_ids else None
             pdf_bytes, invoice_data = self.invoice_service.generate_invoice(
@@ -251,14 +246,27 @@ class InvoiceEmailService:
                 photos = self._get_photo_attachments(list(repairs))
             
             # Look up Stripe payment link from invoice record (if exists)
+            # We search by repair_ids since the invoice_number in invoice_data
+            # is freshly generated and won't match the DB record.
             payment_link = None
             try:
-                from apps.billing.models import Invoice
-                invoice_record = Invoice.objects.filter(
-                    invoice_number=invoice_data.invoice_number
-                ).first()
-                if invoice_record and invoice_record.stripe_hosted_url:
-                    payment_link = invoice_record.stripe_hosted_url
+                from apps.billing.models import InvoiceLineItem
+                if repair_ids:
+                    line_item = InvoiceLineItem.objects.filter(
+                        repair_id__in=repair_ids,
+                        invoice__status__in=['DRAFT', 'SENT', 'PARTIAL'],
+                    ).select_related('invoice').first()
+                    if line_item and line_item.invoice.stripe_hosted_url:
+                        payment_link = line_item.invoice.stripe_hosted_url
+                else:
+                    # Fallback: find most recent invoice for this customer
+                    from apps.billing.models import Invoice
+                    invoice_record = Invoice.objects.filter(
+                        customer_id=customer_id,
+                        stripe_hosted_url__gt='',
+                    ).order_by('-created_at').first()
+                    if invoice_record:
+                        payment_link = invoice_record.stripe_hosted_url
             except Exception:
                 pass
             

--- a/apps/billing/services/invoice_service.py
+++ b/apps/billing/services/invoice_service.py
@@ -147,17 +147,12 @@ class InvoiceService:
             self.HEADER_COLOR = config.secondary_color or ROYAL_BLUE
             self.PRIMARY_COLOR = config.primary_color or "#2C5282"
             
-            # Logo - try to get the file path or URL
+            # Logo - get URL (works for both local and S3 storage)
             if config.logo:
                 try:
-                    # Try local file path first
-                    if hasattr(config.logo, 'path') and os.path.exists(config.logo.path):
-                        self.logo_path = config.logo.path
-                    else:
-                        # Get URL for S3/remote storage
-                        self.logo_url = config.logo.url
+                    self.logo_url = config.logo.url
                 except Exception as e:
-                    print(f"Could not load logo path: {e}")
+                    print(f"Could not load logo URL: {e}")
                     
         except Exception as e:
             print(f"Could not load email branding config: {e}")
@@ -167,34 +162,50 @@ class InvoiceService:
     def _get_logo_for_pdf(self, max_width=3*inch, max_height=1.2*inch):
         """
         Get logo as a ReportLab Image object, properly sized.
+        Supports local files and S3/remote URLs.
         
         Returns:
             RLImage or None if no logo available
         """
+        import tempfile
+        
         if not hasattr(self, 'logo_path') and not hasattr(self, 'logo_url'):
             return None
             
         try:
+            img = None
+            
             # Try local path first
             if hasattr(self, 'logo_path') and self.logo_path and os.path.exists(self.logo_path):
                 img = RLImage(self.logo_path)
             elif hasattr(self, 'logo_url') and self.logo_url:
-                # Download from URL to temp file
-                if self.logo_url.startswith('http'):
-                    # Remote URL
-                    import tempfile
-                    with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as tmp:
-                        urllib.request.urlretrieve(self.logo_url, tmp.name)
-                        img = RLImage(tmp.name)
-                else:
-                    # Local media URL - construct full path
-                    media_root = getattr(settings, 'MEDIA_ROOT', '')
-                    full_path = os.path.join(media_root, self.logo_url.lstrip('/media/'))
-                    if os.path.exists(full_path):
-                        img = RLImage(full_path)
+                url = self.logo_url
+                
+                # Make sure we have a full URL
+                if url.startswith('//'):
+                    url = 'https:' + url
+                elif not url.startswith('http'):
+                    # Try to build full URL from S3 settings
+                    s3_domain = getattr(settings, 'AWS_S3_CUSTOM_DOMAIN', None)
+                    if s3_domain:
+                        url = f'https://{s3_domain}/{url.lstrip("/")}'
                     else:
-                        return None
-            else:
+                        # Local media URL — construct full path
+                        media_root = getattr(settings, 'MEDIA_ROOT', '')
+                        full_path = os.path.join(media_root, url.lstrip('/media/'))
+                        if os.path.exists(full_path):
+                            img = RLImage(full_path)
+                
+                # Download from URL if we haven't loaded yet
+                if img is None and url.startswith('http'):
+                    tmp = tempfile.NamedTemporaryFile(suffix='.jpg', delete=False)
+                    try:
+                        urllib.request.urlretrieve(url, tmp.name)
+                        img = RLImage(tmp.name)
+                    finally:
+                        tmp.close()
+            
+            if img is None:
                 return None
             
             # Calculate aspect ratio and size


### PR DESCRIPTION
## Bugs Fixed

### 1. Stripe payment link never appeared in invoice emails
**Root cause:** `InvoiceEmailService.send_invoice_email()` calls `generate_invoice()` which creates a fresh `InvoiceData` with a new timestamp-based invoice number. It then searched the DB for that new number — which doesn't exist (the real invoice has a different number).

**Fix:** Look up the invoice record by `repair_ids` (via `InvoiceLineItem`) instead of the freshly-generated invoice number. This reliably finds the actual invoice with the Stripe URL.

### 2. Logo not loading on EB production
**Root cause:** Two issues:
- Hardcoded local path (`/home/ubuntu/rswr_systems/media/...`) that doesn't exist on EB
- S3 storage backend doesn't support `.path` attribute — only `.url` works

**Fix:**
- Removed hardcoded local path
- Always use `.url` for logo (works for both S3 and local storage)
- `_get_logo_for_pdf` now downloads from URL to temp file when using S3
- Handles S3 custom domain URLs, relative URLs, and local files