### PR TITLE
feat(billing): payment confirmations + status in portals (phases 4 & 5)

### DIFF
--- a/BILLING_ROADMAP.md
+++ b/BILLING_ROADMAP.md
@@ -70,24 +70,16 @@
 
 ---
 
-## Phase 4: Payment Confirmation Emails ← NEXT
-**Goal**: Notify customer and owner when payment is received.
+## ~~Phase 4: Payment Confirmation Emails~~ ✅ DONE (PR #16)
 
-### 4.1 Customer Payment Receipt
-- Email customer when payment recorded (Stripe webhook or manual entry)
-- Include: amount paid, payment method, remaining balance, invoice number
-- Template consistent with invoice email styling
-
-### 4.2 Owner Payment Notification
-- Email/notify Drake when any payment comes in
-- Include: customer name, amount, method, invoice number
-
-### 4.3 Stripe Refund Handling
-- Handle `charge.refunded` webhook event
-- Update Payment record, adjust Invoice status
-- Notify owner
-
-**Estimated effort**: ~4 hours
+- [x] Customer receipt email (branded HTML + plain text)
+- [x] Shows: amount, method, date, invoice summary, remaining balance
+- [x] "Pay Remaining Balance" button for partial payments with Stripe link
+- [x] Owner notification email (plain text, subject shows amount + customer + status)
+- [x] Wired into Stripe webhook (auto on online payment)
+- [x] Wired into manual payment API (auto on record_payment)
+- [x] Non-fatal — notification failures don't break payment recording
+- [ ] Stripe refund handling (charge.refunded webhook → future)
 
 ---
 
@@ -157,7 +149,7 @@
 | ✅ | 1 | Payment terms & BillingConfig | DONE | — |
 | ✅ | 2 | Stripe integration | DONE (needs webhook secret) | — |
 | ✅ | 3 | Company address on invoices | DONE | — |
-| 🔴 P0 | 4 | Payment confirmation emails | NEXT | ~4 |
+| ✅ | 4 | Payment confirmation emails | DONE | — |
 | 🟡 P1 | 5 | Payment status in portals | — | ~15 |
 | 🟢 P2 | 6 | Automation & reports | — | ~12 |
 

--- a/apps/billing/services/payment_notification_service.py
+++ b/apps/billing/services/payment_notification_service.py
@@ -1,0 +1,210 @@
+"""
+Payment Notification Service — sends confirmation emails when payments are received.
+
+Sends to:
+1. Customer — payment receipt with invoice summary
+2. Owner — notification that payment came in
+
+Triggered by:
+- Stripe webhook (automatic online payment)
+- Manual payment recording (check, cash, COD)
+
+Author: Amelia (Clawdbot AI)
+"""
+
+import logging
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
+from django.utils.html import strip_tags
+
+logger = logging.getLogger(__name__)
+
+
+class PaymentNotificationService:
+    """
+    Sends payment confirmation emails to customers and owner.
+    """
+
+    def __init__(self):
+        self._branding = None
+
+    @property
+    def branding(self):
+        """Lazy-load email branding config."""
+        if self._branding is None:
+            try:
+                from core.models.email_branding import EmailBrandingConfig
+                self._branding = EmailBrandingConfig.get_instance().to_template_context()
+            except Exception:
+                self._branding = {
+                    'company_name': 'RS Systems',
+                    'primary_color': '#2C5282',
+                    'secondary_color': '#4299E1',
+                    'success_color': '#38A169',
+                    'danger_color': '#E53E3E',
+                    'text_color': '#2D3748',
+                    'background_color': '#F7FAFC',
+                    'heading_font': 'Arial, Helvetica, sans-serif',
+                    'body_font': 'Arial, Helvetica, sans-serif',
+                    'button_border_radius': 4,
+                    'support_email': '',
+                    'support_phone': '',
+                }
+        return self._branding
+
+    def send_customer_receipt(self, payment):
+        """
+        Send payment confirmation email to the customer.
+
+        Args:
+            payment: Payment model instance
+
+        Returns:
+            bool: True if sent successfully
+        """
+        invoice = payment.invoice
+        customer = invoice.customer
+
+        # Find recipient email
+        recipient = None
+        try:
+            prefs = customer.repair_preferences
+            recipient = prefs.billing_email
+        except Exception:
+            pass
+        recipient = recipient or customer.email
+
+        if not recipient:
+            logger.warning(
+                f"No email for customer {customer.id} — skipping payment receipt"
+            )
+            return False
+
+        try:
+            context = {
+                'payment': payment,
+                'invoice': invoice,
+                'customer': customer,
+                'branding': self.branding,
+            }
+
+            subject = (
+                f"[{self.branding.get('company_name', 'RS Systems')}] "
+                f"Payment Received — Invoice {invoice.invoice_number}"
+            )
+
+            html_body = render_to_string(
+                'emails/notifications/payment_received.html', context
+            )
+            text_body = render_to_string(
+                'emails/notifications/payment_received.txt', context
+            )
+
+            email = EmailMultiAlternatives(
+                subject=subject,
+                body=text_body,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                to=[recipient],
+            )
+            email.attach_alternative(html_body, 'text/html')
+            email.send()
+
+            logger.info(
+                f"Payment receipt sent to {recipient} for "
+                f"${payment.amount} on {invoice.invoice_number}"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to send payment receipt: {e}")
+            return False
+
+    def send_owner_notification(self, payment):
+        """
+        Send payment notification to the business owner.
+
+        Args:
+            payment: Payment model instance
+
+        Returns:
+            bool: True if sent successfully
+        """
+        invoice = payment.invoice
+        customer = invoice.customer
+
+        # Get owner email from BillingConfig or fallback
+        owner_email = None
+        try:
+            from apps.billing.models import BillingConfig
+            cfg = BillingConfig.get_instance()
+            owner_email = cfg.company_email
+        except Exception:
+            pass
+
+        if not owner_email:
+            owner_email = getattr(settings, 'DEFAULT_OWNER_EMAIL', None)
+
+        if not owner_email:
+            logger.debug("No owner email configured — skipping owner notification")
+            return False
+
+        try:
+            status_text = 'PAID IN FULL' if invoice.status == 'PAID' else f'${invoice.amount_due} remaining'
+
+            subject = (
+                f"💰 Payment: ${payment.amount} from {customer.name} "
+                f"({status_text})"
+            )
+
+            body = (
+                f"Payment received!\n\n"
+                f"Customer:       {customer.name}\n"
+                f"Invoice:        {invoice.invoice_number}\n"
+                f"Amount:         ${payment.amount}\n"
+                f"Method:         {payment.get_payment_method_display()}\n"
+                f"Date:           {payment.payment_date}\n"
+                f"{'Reference:      ' + payment.reference_number + chr(10) if payment.reference_number else ''}"
+                f"\n"
+                f"Invoice Total:  ${invoice.total}\n"
+                f"Total Paid:     ${invoice.amount_paid}\n"
+                f"Balance:        ${invoice.amount_due}\n"
+                f"Status:         {invoice.get_status_display()}\n"
+            )
+
+            email = EmailMultiAlternatives(
+                subject=subject,
+                body=body,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                to=[owner_email],
+            )
+            email.send()
+
+            logger.info(
+                f"Owner notified of ${payment.amount} payment from {customer.name}"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to send owner payment notification: {e}")
+            return False
+
+    def notify_payment(self, payment):
+        """
+        Main entry point — send both customer receipt and owner notification.
+
+        Args:
+            payment: Payment model instance
+
+        Returns:
+            dict: {customer_sent: bool, owner_sent: bool}
+        """
+        result = {
+            'customer_sent': False,
+            'owner_sent': False,
+        }
+
+        result['customer_sent'] = self.send_customer_receipt(payment)
+        result['owner_sent'] = self.send_owner_notification(payment)
+
+        return result

--- a/apps/billing/services/stripe_service.py
+++ b/apps/billing/services/stripe_service.py
@@ -319,7 +319,7 @@ class StripeService:
             return {'success': True, 'duplicate': True}
         
         tracking = InvoiceTrackingService()
-        tracking.record_payment(
+        payment = tracking.record_payment(
             invoice=invoice,
             amount=amount,
             payment_method='STRIPE',
@@ -328,6 +328,16 @@ class StripeService:
         )
         
         logger.info(f"Stripe payment ${amount} recorded for {invoice.invoice_number}")
+        
+        # Send payment confirmation emails
+        try:
+            from apps.billing.services.payment_notification_service import PaymentNotificationService
+            invoice.refresh_from_db()  # Reload to get updated status/amounts
+            notif = PaymentNotificationService()
+            notif_result = notif.notify_payment(payment)
+            logger.info(f"Payment notifications: customer={notif_result['customer_sent']}, owner={notif_result['owner_sent']}")
+        except Exception as e:
+            logger.warning(f"Payment notification failed (non-fatal): {e}")
         
         return {
             'success': True,

--- a/apps/billing/templatetags/billing_tags.py
+++ b/apps/billing/templatetags/billing_tags.py
@@ -1,0 +1,52 @@
+"""
+Billing template tags — invoice/payment status lookups for repair detail pages.
+
+Usage:
+    {% load billing_tags %}
+    {% get_invoice_status repair as inv_status %}
+    {% if inv_status %}
+        {{ inv_status.status }}  — PAID, SENT, OVERDUE, etc.
+        {{ inv_status.invoice_number }}
+        {{ inv_status.total }}
+        {{ inv_status.amount_due }}
+        {{ inv_status.stripe_url }}
+    {% endif %}
+
+Author: Amelia (Clawdbot AI)
+"""
+
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_invoice_status(repair):
+    """
+    Look up the invoice status for a repair.
+    Returns a dict with invoice info, or None if not invoiced.
+    """
+    try:
+        from apps.billing.models import InvoiceLineItem
+
+        line_item = InvoiceLineItem.objects.filter(
+            repair=repair,
+            invoice__status__in=['DRAFT', 'SENT', 'PARTIAL', 'PAID', 'OVERDUE'],
+        ).select_related('invoice').first()
+
+        if not line_item:
+            return None
+
+        invoice = line_item.invoice
+        return {
+            'status': invoice.status,
+            'invoice_number': invoice.invoice_number,
+            'total': invoice.total,
+            'amount_paid': invoice.amount_paid,
+            'amount_due': invoice.amount_due,
+            'due_date': invoice.due_date,
+            'stripe_url': invoice.stripe_hosted_url or '',
+            'payment_terms': invoice.get_payment_terms_display(),
+        }
+    except Exception:
+        return None

--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -390,6 +390,15 @@ def record_payment(request, invoice_id):
 
         invoice.refresh_from_db()
 
+        # Send payment confirmation emails (non-blocking)
+        notif_result = {'customer_sent': False, 'owner_sent': False}
+        if not data.get('skip_notifications', False):
+            try:
+                from apps.billing.services.payment_notification_service import PaymentNotificationService
+                notif_result = PaymentNotificationService().notify_payment(payment)
+            except Exception:
+                pass
+
         return JsonResponse({
             'success': True,
             'payment': {
@@ -404,6 +413,7 @@ def record_payment(request, invoice_id):
                 'amount_due': float(invoice.amount_due),
                 'status': invoice.status,
             },
+            'notifications': notif_result,
         })
     except ValueError as e:
         return JsonResponse({'error': str(e)}, status=400)

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -288,6 +288,63 @@ def onboarding_view(request):
 # 4. Owner dashboard
 # ------------------------------------------------------------------
 
+
+def _get_billing_context(tenant):
+    """Build billing summary context for the owner dashboard."""
+    from apps.billing.models import Invoice, Payment
+    from django.db.models import Sum, Count, Q
+    from decimal import Decimal
+
+    try:
+        # Outstanding invoices
+        outstanding = Invoice.objects.filter(
+            tenant=tenant,
+            status__in=['SENT', 'PARTIAL', 'OVERDUE'],
+        ).select_related('customer').order_by('due_date')
+
+        total_outstanding = outstanding.aggregate(
+            total=Sum('total') - Sum('amount_paid')
+        )
+        outstanding_amount = (total_outstanding.get('total') or Decimal('0.00'))
+
+        overdue_count = outstanding.filter(status='OVERDUE').count()
+
+        # Recent payments (last 10)
+        recent_payments = Payment.objects.filter(
+            invoice__tenant=tenant,
+        ).select_related(
+            'invoice', 'invoice__customer'
+        ).order_by('-payment_date', '-created_at')[:10]
+
+        # Payments this month
+        from django.utils import timezone
+        now = timezone.now()
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        payments_this_month = Payment.objects.filter(
+            invoice__tenant=tenant,
+            created_at__gte=month_start,
+        ).aggregate(total=Sum('amount'))
+        collected_this_month = payments_this_month.get('total') or Decimal('0.00')
+
+        return {
+            'outstanding_invoices': outstanding[:10],
+            'outstanding_count': outstanding.count(),
+            'outstanding_amount': outstanding_amount,
+            'overdue_count': overdue_count,
+            'recent_payments': recent_payments,
+            'collected_this_month': collected_this_month,
+        }
+    except Exception:
+        return {
+            'outstanding_invoices': [],
+            'outstanding_count': 0,
+            'outstanding_amount': Decimal('0.00'),
+            'overdue_count': 0,
+            'recent_payments': [],
+            'collected_this_month': Decimal('0.00'),
+        }
+
+
 @owner_or_manager_required
 def owner_dashboard(request):
     """Owner dashboard with trial banner, usage, quick actions, recent activity."""
@@ -318,6 +375,9 @@ def owner_dashboard(request):
         reverse=True,
     )[:5]
 
+    # Billing summary
+    billing_context = _get_billing_context(tenant)
+
     context = {
         'tenant': tenant,
         'membership': membership,
@@ -327,6 +387,7 @@ def owner_dashboard(request):
         'is_trial': tenant.plan == 'trial',
         'is_trial_expired': tenant.is_trial_expired,
     }
+    context.update(billing_context)
     return render(request, 'saas/owner_dashboard.html', context)
 
 

--- a/templates/customer_portal/repair_detail.html
+++ b/templates/customer_portal/repair_detail.html
@@ -1,4 +1,5 @@
 {% extends 'customer_portal/base_customer.html' %}
+{% load billing_tags %}
 
 {% block extra_css %}
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -87,6 +88,37 @@
                         {% endif %}
                         {% endwith %}
                     </div>
+                    {% endif %}
+
+                    <!-- Invoice / Payment Status -->
+                    {% if repair.queue_status == 'COMPLETED' %}
+                    {% get_invoice_status repair as inv_status %}
+                    {% if inv_status %}
+                    <div class="row mb-3">
+                        <div class="col-md-4 fw-bold">Invoice Status:</div>
+                        <div class="col-md-8">
+                            {% if inv_status.status == 'PAID' %}
+                            <span class="badge bg-success"><i class="fas fa-check-circle me-1"></i>Paid</span>
+                            <span class="text-muted ms-2">${{ inv_status.total|floatformat:2 }}</span>
+                            {% elif inv_status.status == 'OVERDUE' %}
+                            <span class="badge bg-danger"><i class="fas fa-exclamation-circle me-1"></i>Overdue</span>
+                            <span class="text-danger ms-2 fw-bold">${{ inv_status.amount_due|floatformat:2 }} due</span>
+                            {% elif inv_status.status == 'PARTIAL' %}
+                            <span class="badge bg-warning text-dark"><i class="fas fa-clock me-1"></i>Partially Paid</span>
+                            <span class="text-muted ms-2">${{ inv_status.amount_due|floatformat:2 }} remaining</span>
+                            {% elif inv_status.status == 'SENT' %}
+                            <span class="badge bg-primary"><i class="fas fa-paper-plane me-1"></i>Invoice Sent</span>
+                            <span class="text-muted ms-2">${{ inv_status.amount_due|floatformat:2 }} due</span>
+                            {% endif %}
+                            {% if inv_status.stripe_url and inv_status.amount_due > 0 %}
+                            <a href="{{ inv_status.stripe_url }}" target="_blank" class="btn btn-sm btn-outline-primary ms-2">
+                                <i class="fas fa-credit-card me-1"></i>Pay Online
+                            </a>
+                            {% endif %}
+                            <div class="small text-muted mt-1">{{ inv_status.invoice_number }} · {{ inv_status.payment_terms }}</div>
+                        </div>
+                    </div>
+                    {% endif %}
                     {% endif %}
                     
                     <!-- Photo Documentation Section -->

--- a/templates/emails/notifications/payment_received.html
+++ b/templates/emails/notifications/payment_received.html
@@ -1,0 +1,172 @@
+{% extends "emails/base.html" %}
+
+{% block email_title %}Payment Received - Invoice {{ invoice.invoice_number }}{% endblock %}
+
+{% block preheader %}We received your payment of ${{ payment.amount }} for invoice {{ invoice.invoice_number }}. {% if invoice.status == 'PAID' %}Your invoice is now paid in full.{% else %}Remaining balance: ${{ invoice.amount_due }}.{% endif %}{% endblock %}
+
+{% block content %}
+<!-- Success Badge -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+    <tr>
+        <td style="text-align: center; padding-bottom: 20px;">
+            <div style="display: inline-block; background-color: {{ branding.success_color }}; color: white; padding: 10px 20px; border-radius: {{ branding.button_border_radius }}px; font-family: {{ branding.heading_font }}; font-size: 14px; font-weight: bold; letter-spacing: 0.5px;">
+                ✓ PAYMENT RECEIVED
+            </div>
+        </td>
+    </tr>
+</table>
+
+<!-- Main Heading -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+    <tr>
+        <td style="padding-bottom: 20px;">
+            <h1 style="margin: 0; color: {{ branding.text_color }}; font-family: {{ branding.heading_font }}; font-size: 24px; font-weight: bold; line-height: 1.3;">
+                Payment Confirmed 💳
+            </h1>
+            <p style="margin: 10px 0 0 0; color: #666666; font-family: {{ branding.body_font }}; font-size: 16px; line-height: 24px;">
+                Thank you for your payment{% if invoice.customer %}, {{ invoice.customer.name }}{% endif %}.
+                {% if invoice.status == 'PAID' %}Your invoice has been paid in full.{% endif %}
+            </p>
+        </td>
+    </tr>
+</table>
+
+<!-- Payment Details Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #f0fdf4; border: 2px solid {{ branding.success_color }}; border-radius: 8px; margin-bottom: 30px;">
+    <tr>
+        <td style="padding: 25px;">
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                    <td style="padding-bottom: 15px;">
+                        <h2 style="margin: 0; color: {{ branding.success_color }}; font-family: {{ branding.heading_font }}; font-size: 18px; font-weight: bold;">
+                            Payment Details
+                        </h2>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                            <tr>
+                                <td style="padding: 8px 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 20px;">
+                                    <strong style="color: {{ branding.text_color }};">Amount Paid:</strong>
+                                    <span style="color: {{ branding.success_color }}; font-weight: bold; font-size: 18px;">${{ payment.amount }}</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 20px;">
+                                    <strong style="color: {{ branding.text_color }};">Payment Method:</strong>
+                                    <span style="color: #666666;">{{ payment.get_payment_method_display }}</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 20px;">
+                                    <strong style="color: {{ branding.text_color }};">Payment Date:</strong>
+                                    <span style="color: #666666;">{{ payment.payment_date|date:"M d, Y" }}</span>
+                                </td>
+                            </tr>
+                            {% if payment.reference_number %}
+                            <tr>
+                                <td style="padding: 8px 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 20px;">
+                                    <strong style="color: {{ branding.text_color }};">Reference:</strong>
+                                    <span style="color: #666666;">{{ payment.reference_number }}</span>
+                                </td>
+                            </tr>
+                            {% endif %}
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+<!-- Invoice Summary Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #f8f9fa; border: 1px solid #e2e8f0; border-radius: 8px; margin-bottom: 30px;">
+    <tr>
+        <td style="padding: 25px;">
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                    <td style="padding-bottom: 15px;">
+                        <h2 style="margin: 0; color: {{ branding.text_color }}; font-family: {{ branding.heading_font }}; font-size: 18px; font-weight: bold;">
+                            Invoice Summary
+                        </h2>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                            <tr>
+                                <td style="padding: 8px 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 20px;">
+                                    <strong style="color: {{ branding.text_color }};">Invoice #:</strong>
+                                    <span style="color: #666666;">{{ invoice.invoice_number }}</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 20px;">
+                                    <strong style="color: {{ branding.text_color }};">Invoice Total:</strong>
+                                    <span style="color: #666666;">${{ invoice.total }}</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 20px;">
+                                    <strong style="color: {{ branding.text_color }};">Total Paid:</strong>
+                                    <span style="color: {{ branding.success_color }};">${{ invoice.amount_paid }}</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 20px; border-top: 2px solid #e2e8f0;">
+                                    <strong style="color: {{ branding.text_color }};">Remaining Balance:</strong>
+                                    {% if invoice.amount_due > 0 %}
+                                    <span style="color: {{ branding.danger_color }}; font-weight: bold;">${{ invoice.amount_due }}</span>
+                                    {% else %}
+                                    <span style="color: {{ branding.success_color }}; font-weight: bold;">$0.00 — PAID IN FULL ✓</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 20px;">
+                                    <strong style="color: {{ branding.text_color }};">Status:</strong>
+                                    {% if invoice.status == 'PAID' %}
+                                    <span style="background-color: {{ branding.success_color }}; color: white; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: bold;">PAID</span>
+                                    {% elif invoice.status == 'PARTIAL' %}
+                                    <span style="background-color: #ffc107; color: #333; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: bold;">PARTIALLY PAID</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+<!-- Pay remaining balance button (if partial) -->
+{% if invoice.amount_due > 0 and invoice.stripe_hosted_url %}
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom: 20px;">
+    <tr>
+        <td style="text-align: center; padding: 20px 0;">
+            <a href="{{ invoice.stripe_hosted_url }}" style="background-color: {{ branding.primary_color }}; color: white; text-decoration: none; padding: 14px 35px; border-radius: {{ branding.button_border_radius }}px; font-family: {{ branding.heading_font }}; font-size: 16px; font-weight: bold; display: inline-block;">
+                Pay Remaining Balance
+            </a>
+        </td>
+    </tr>
+</table>
+{% endif %}
+
+<!-- Thank You Note -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+    <tr>
+        <td style="padding: 20px; background-color: #f0f8ff; border-left: 4px solid {{ branding.secondary_color }}; border-radius: 0 4px 4px 0;">
+            <p style="margin: 0; font-family: {{ branding.body_font }}; font-size: 14px; line-height: 22px; color: #555555;">
+                <strong style="color: {{ branding.text_color }};">Thank you for your prompt payment!</strong><br>
+                If you have any questions about this payment or invoice, please don't hesitate to reach out.
+                {% if branding.support_email %}<br><br>Contact us at <a href="mailto:{{ branding.support_email }}" style="color: {{ branding.primary_color }}; text-decoration: none;">{{ branding.support_email }}</a>{% endif %}
+                {% if branding.support_phone %} or <a href="tel:{{ branding.support_phone }}" style="color: {{ branding.primary_color }}; text-decoration: none;">{{ branding.support_phone }}</a>{% endif %}
+            </p>
+        </td>
+    </tr>
+</table>
+{% endblock %}
+
+{% block unsubscribe_url %}/app/settings/notifications/{% endblock %}

--- a/templates/emails/notifications/payment_received.txt
+++ b/templates/emails/notifications/payment_received.txt
@@ -1,0 +1,27 @@
+PAYMENT RECEIVED
+
+Thank you for your payment{% if invoice.customer %}, {{ invoice.customer.name }}{% endif %}.
+
+PAYMENT DETAILS
+-----------------------------------------
+Amount Paid:    ${{ payment.amount }}
+Payment Method: {{ payment.get_payment_method_display }}
+Payment Date:   {{ payment.payment_date|date:"M d, Y" }}{% if payment.reference_number %}
+Reference:      {{ payment.reference_number }}{% endif %}
+
+INVOICE SUMMARY
+-----------------------------------------
+Invoice #:         {{ invoice.invoice_number }}
+Invoice Total:     ${{ invoice.total }}
+Total Paid:        ${{ invoice.amount_paid }}
+Remaining Balance: {% if invoice.amount_due > 0 %}${{ invoice.amount_due }}{% else %}$0.00 - PAID IN FULL{% endif %}
+Status:            {{ invoice.get_status_display }}
+
+{% if invoice.amount_due > 0 and invoice.stripe_hosted_url %}Pay remaining balance online: {{ invoice.stripe_hosted_url }}
+{% endif %}
+Thank you for your prompt payment!
+
+--
+{{ branding.company_name }}{% if branding.support_email %}
+{{ branding.support_email }}{% endif %}{% if branding.support_phone %}
+{{ branding.support_phone }}{% endif %}

--- a/templates/includes/invoice_status_badge.html
+++ b/templates/includes/invoice_status_badge.html
@@ -1,0 +1,53 @@
+{% comment %}
+Invoice/Payment status badge for a repair.
+Expects `repair` in context. Shows invoice status if the repair has been invoiced.
+{% endcomment %}
+{% load billing_tags %}
+{% get_invoice_status repair as inv_status %}
+{% if inv_status %}
+<div class="{% if badge_class %}{{ badge_class }}{% else %}mt-3 p-3 rounded-lg border{% endif %}
+    {% if inv_status.status == 'PAID' %}bg-green-50 border-green-200
+    {% elif inv_status.status == 'OVERDUE' %}bg-red-50 border-red-200
+    {% elif inv_status.status == 'PARTIAL' %}bg-yellow-50 border-yellow-200
+    {% elif inv_status.status == 'SENT' %}bg-blue-50 border-blue-200
+    {% else %}bg-gray-50 border-gray-200{% endif %}">
+    <div class="flex items-center justify-between">
+        <div class="flex items-center space-x-2">
+            {% if inv_status.status == 'PAID' %}
+            <i class="fas fa-check-circle text-green-600"></i>
+            <span class="text-sm font-medium text-green-800">Paid</span>
+            {% elif inv_status.status == 'OVERDUE' %}
+            <i class="fas fa-exclamation-circle text-red-600"></i>
+            <span class="text-sm font-medium text-red-800">Overdue</span>
+            {% elif inv_status.status == 'PARTIAL' %}
+            <i class="fas fa-clock text-yellow-600"></i>
+            <span class="text-sm font-medium text-yellow-800">Partially Paid</span>
+            {% elif inv_status.status == 'SENT' %}
+            <i class="fas fa-paper-plane text-blue-600"></i>
+            <span class="text-sm font-medium text-blue-800">Invoice Sent</span>
+            {% elif inv_status.status == 'DRAFT' %}
+            <i class="fas fa-file text-gray-600"></i>
+            <span class="text-sm font-medium text-gray-800">Invoice Draft</span>
+            {% endif %}
+            <span class="text-xs text-gray-500">{{ inv_status.invoice_number }}</span>
+        </div>
+        <div class="text-right">
+            {% if inv_status.status == 'PAID' %}
+            <span class="text-sm font-semibold text-green-700">${{ inv_status.total|floatformat:2 }}</span>
+            {% elif inv_status.amount_due > 0 %}
+            <span class="text-sm font-semibold
+                {% if inv_status.status == 'OVERDUE' %}text-red-700{% else %}text-gray-900{% endif %}">
+                ${{ inv_status.amount_due|floatformat:2 }} due
+            </span>
+            {% endif %}
+        </div>
+    </div>
+    {% if inv_status.stripe_url and inv_status.amount_due > 0 %}
+    <div class="mt-2">
+        <a href="{{ inv_status.stripe_url }}" target="_blank" class="inline-flex items-center text-xs font-medium text-blue-600 hover:text-blue-800">
+            <i class="fas fa-credit-card mr-1"></i> Pay Online
+        </a>
+    </div>
+    {% endif %}
+</div>
+{% endif %}

--- a/templates/saas/owner_dashboard.html
+++ b/templates/saas/owner_dashboard.html
@@ -151,6 +151,124 @@
     </div>
 </div>
 
+<!-- Billing Overview -->
+{% if outstanding_count > 0 or recent_payments %}
+<div class="mb-8">
+    <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold text-gray-900">Billing</h2>
+    </div>
+
+    <!-- Billing Metric Cards -->
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+            <div class="flex items-center justify-between mb-2">
+                <span class="text-sm font-medium text-gray-500">Outstanding</span>
+                <div class="w-8 h-8 bg-amber-100 rounded-lg flex items-center justify-center">
+                    <i class="fas fa-file-invoice-dollar text-amber-600 text-sm"></i>
+                </div>
+            </div>
+            <div class="text-2xl font-bold text-gray-900">${{ outstanding_amount|floatformat:2 }}</div>
+            <p class="text-xs text-gray-500 mt-1">{{ outstanding_count }} invoice{{ outstanding_count|pluralize }}</p>
+        </div>
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+            <div class="flex items-center justify-between mb-2">
+                <span class="text-sm font-medium text-gray-500">Overdue</span>
+                <div class="w-8 h-8 {% if overdue_count > 0 %}bg-red-100{% else %}bg-green-100{% endif %} rounded-lg flex items-center justify-center">
+                    <i class="fas fa-exclamation-circle {% if overdue_count > 0 %}text-red-600{% else %}text-green-600{% endif %} text-sm"></i>
+                </div>
+            </div>
+            <div class="text-2xl font-bold {% if overdue_count > 0 %}text-red-600{% else %}text-green-600{% endif %}">{{ overdue_count }}</div>
+            <p class="text-xs text-gray-500 mt-1">{% if overdue_count > 0 %}Need attention{% else %}All current{% endif %}</p>
+        </div>
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+            <div class="flex items-center justify-between mb-2">
+                <span class="text-sm font-medium text-gray-500">Collected This Month</span>
+                <div class="w-8 h-8 bg-green-100 rounded-lg flex items-center justify-center">
+                    <i class="fas fa-money-bill-wave text-green-600 text-sm"></i>
+                </div>
+            </div>
+            <div class="text-2xl font-bold text-green-600">${{ collected_this_month|floatformat:2 }}</div>
+            <p class="text-xs text-gray-500 mt-1">Payments received</p>
+        </div>
+    </div>
+
+    <!-- Outstanding Invoices Table -->
+    {% if outstanding_invoices %}
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200 mb-6">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-sm font-semibold text-gray-900">Outstanding Invoices</h3>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Invoice</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Customer</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Due Date</th>
+                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Amount Due</th>
+                        <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-100">
+                    {% for inv in outstanding_invoices %}
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ inv.invoice_number }}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{{ inv.customer.name }}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                            {% if inv.due_date %}{{ inv.due_date|date:"M d, Y" }}{% else %}—{% endif %}
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold text-right
+                            {% if inv.status == 'OVERDUE' %}text-red-600{% else %}text-gray-900{% endif %}">
+                            ${{ inv.amount_due|floatformat:2 }}
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-center">
+                            {% if inv.status == 'OVERDUE' %}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">Overdue</span>
+                            {% elif inv.status == 'PARTIAL' %}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">Partial</span>
+                            {% else %}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Sent</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Recent Payments -->
+    {% if recent_payments %}
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-sm font-semibold text-gray-900">Recent Payments</h3>
+        </div>
+        <div class="divide-y divide-gray-100">
+            {% for p in recent_payments %}
+            <div class="px-6 py-3 flex items-center justify-between hover:bg-gray-50">
+                <div class="flex items-center space-x-3">
+                    <div class="w-8 h-8 bg-green-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                        <i class="fas fa-check text-green-600 text-xs"></i>
+                    </div>
+                    <div>
+                        <span class="text-sm font-medium text-gray-900">{{ p.invoice.customer.name }}</span>
+                        <span class="text-xs text-gray-500 ml-2">{{ p.invoice.invoice_number }}</span>
+                    </div>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-xs text-gray-500">{{ p.get_payment_method_display }}</span>
+                    <span class="text-sm font-semibold text-green-600">+${{ p.amount|floatformat:2 }}</span>
+                    <span class="text-xs text-gray-400">{{ p.payment_date|date:"M d" }}</span>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endif %}
+
 <!-- Quick Actions -->
 <div class="mb-8">
     <h2 class="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>

--- a/templates/technician_portal/repair_detail.html
+++ b/templates/technician_portal/repair_detail.html
@@ -1,4 +1,5 @@
 {% extends "base_app.html" %}
+{% load billing_tags %}
 
 {% block extra_css %}
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -317,6 +318,11 @@
                         </div>
                         {% endif %}
                         {% endwith %}
+
+                        <!-- Invoice/Payment Status -->
+                        {% if repair.queue_status == 'COMPLETED' %}
+                        {% include "includes/invoice_status_badge.html" %}
+                        {% endif %}
                     </div>
                 </div>
             


### PR DESCRIPTION
## Phase 4: Payment Confirmation Emails

When a payment is recorded (Stripe webhook or manual entry), both the customer and the business owner now get notified.

### Customer Receipt Email
- Branded HTML email matching existing notification style (extends `emails/base.html`)
- Shows: amount paid, payment method, date, reference number
- Invoice summary: total, amount paid, remaining balance, status badge
- If partial payment + Stripe link exists: "Pay Remaining Balance" button
- Plain text fallback included

### Owner Notification
- Plain text email with subject: `💰 Payment: $50 from EOS Trucking (PAID IN FULL)`
- Quick-scan format: customer, invoice, amount, method, balance

### Wired Into
- **Stripe webhook** → `_record_stripe_payment()` auto-sends both emails after recording
- **Manual payment API** → `record_payment` view sends both (opt out: `skip_notifications=true`)
- All notification failures are non-fatal (logged, don't break the payment flow)

### Owner email
Pulls from `BillingConfig.company_email`. If not set, falls back to `DEFAULT_OWNER_EMAIL` setting.

### No migration needed
Templates + service code only.