### PR TITLE
feat: Auto-email on invoice creation + batch email send

### DIFF
--- a/apps/billing/urls.py
+++ b/apps/billing/urls.py
@@ -28,6 +28,9 @@ urlpatterns = [
     path('invoices/<int:invoice_id>/payment/', views.record_payment, name='invoice_payment'),
     path('invoices/<int:invoice_id>/cancel/', views.cancel_invoice, name='invoice_cancel'),
     
+    path('invoices/<int:invoice_id>/send-email/', views.send_invoice_email, name='invoice_send_email'),
+    path('invoices/send-email-batch/', views.send_invoice_email_batch, name='invoice_send_email_batch'),
+
     # Customer billing
     path('customers/<int:customer_id>/uninvoiced/', views.get_uninvoiced_repairs, name='uninvoiced_repairs'),
     path('customers/<int:customer_id>/balance/', views.get_customer_balance, name='customer_balance'),

--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -292,6 +292,82 @@ def create_invoice(request, customer_id):
 
 
 @login_required
+@require_POST
+def send_invoice_email(request, invoice_id):
+    """Send (or resend) an invoice email to the customer."""
+    tenant, err = _get_tenant_or_403(request)
+    if err:
+        return err
+
+    try:
+        invoice = Invoice.objects.get(id=invoice_id, tenant=tenant)
+    except Invoice.DoesNotExist:
+        return JsonResponse({'error': 'Invoice not found'}, status=404)
+
+    if not invoice.customer.email:
+        return JsonResponse({'error': f'No email address for {invoice.customer.name}'}, status=400)
+
+    try:
+        from apps.billing.services.invoice_email_service import InvoiceEmailService
+        email_svc = InvoiceEmailService()
+        repair_ids = list(invoice.line_items.values_list('repair_id', flat=True))
+        email_svc.send_invoice_email(
+            customer_id=invoice.customer_id,
+            recipient_email=invoice.customer.email,
+            repair_ids=repair_ids if repair_ids else None,
+        )
+        return JsonResponse({'success': True, 'sent_to': invoice.customer.email})
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).exception(f"Email send failed for {invoice.invoice_number}")
+        return JsonResponse({'error': f'Email failed: {str(e)}'}, status=500)
+
+
+@login_required
+@require_POST
+def send_invoice_email_batch(request):
+    """Send invoice emails for multiple invoices at once."""
+    tenant, err = _get_tenant_or_403(request)
+    if err:
+        return err
+
+    try:
+        data = json.loads(request.body)
+        invoice_ids = data.get('invoice_ids', [])
+    except (json.JSONDecodeError, AttributeError):
+        return JsonResponse({'error': 'Invalid JSON'}, status=400)
+
+    if not invoice_ids:
+        return JsonResponse({'error': 'No invoice IDs provided'}, status=400)
+
+    from apps.billing.services.invoice_email_service import InvoiceEmailService
+    email_svc = InvoiceEmailService()
+
+    results = []
+    for inv_id in invoice_ids:
+        try:
+            invoice = Invoice.objects.get(id=inv_id, tenant=tenant)
+            if not invoice.customer.email:
+                results.append({'id': inv_id, 'success': False, 'error': 'No email'})
+                continue
+            repair_ids = list(invoice.line_items.values_list('repair_id', flat=True))
+            email_svc.send_invoice_email(
+                customer_id=invoice.customer_id,
+                recipient_email=invoice.customer.email,
+                repair_ids=repair_ids if repair_ids else None,
+            )
+            results.append({'id': inv_id, 'success': True, 'sent_to': invoice.customer.email})
+        except Invoice.DoesNotExist:
+            results.append({'id': inv_id, 'success': False, 'error': 'Not found'})
+        except Exception as e:
+            results.append({'id': inv_id, 'success': False, 'error': str(e)})
+
+    sent = sum(1 for r in results if r['success'])
+    failed = len(results) - sent
+    return JsonResponse({'success': True, 'sent': sent, 'failed': failed, 'results': results})
+
+
+@login_required
 @require_GET
 def get_invoice(request, invoice_id):
     """Get detailed invoice with line items and payments."""

--- a/docs/development/FUTURE_FEATURES.md
+++ b/docs/development/FUTURE_FEATURES.md
@@ -112,3 +112,16 @@ Wire SubscriptionPlan to Stripe Products/Prices. Checkout flow, subscription web
 - [`BILLING_ROADMAP.md`](/BILLING_ROADMAP.md) — Detailed billing phases
 - [`docs/development/CHANGELOG.md`](CHANGELOG.md) — Version history
 - [`docs/AMELIA_ROADMAP.md`](../AMELIA_ROADMAP.md) — High-level roadmap
+
+## Custom Contact Email on Payment Pages
+**Priority**: P1 (needs real email before production)
+**Status**: Waiting on Drake to set up appropriate email
+
+The payment-complete and payment-cancelled pages currently show `info@rockstarwindshield.repair` which is a send-only/no-reply address. Need to replace with a real reply-to email customers can actually reach.
+
+**Files to update:**
+- `templates/billing/payment_complete.html`
+- `templates/billing/payment_cancelled.html`
+- Possibly `templates/emails/` notification templates if they reference this address
+
+**Action needed:** Drake sets up an email (e.g. `support@rockstarwindshield.repair`), then update all templates.

--- a/templates/saas/owner_invoices.html
+++ b/templates/saas/owner_invoices.html
@@ -124,6 +124,21 @@
 </div>
 {% endif %}
 
+<!-- Batch Actions Bar (hidden until checkboxes selected) -->
+<div id="batch-bar" class="hidden sticky top-0 z-10 bg-blue-600 text-white rounded-xl shadow-lg p-3 mb-4 flex items-center justify-between">
+    <div class="flex items-center gap-3">
+        <span class="text-sm font-medium"><span id="selected-count">0</span> invoice(s) selected</span>
+    </div>
+    <div class="flex items-center gap-2">
+        <button onclick="sendSelectedEmails()" class="inline-flex items-center px-4 py-1.5 bg-white text-blue-700 text-sm font-medium rounded-lg hover:bg-blue-50 transition-colors">
+            <i class="fas fa-envelope mr-1.5"></i>Send Email
+        </button>
+        <button onclick="clearSelection()" class="inline-flex items-center px-3 py-1.5 text-blue-200 text-sm hover:text-white transition-colors">
+            <i class="fas fa-times mr-1"></i>Clear
+        </button>
+    </div>
+</div>
+
 <!-- Invoice Table -->
 <div class="bg-white rounded-xl shadow-sm border border-gray-200">
     {% if invoices %}
@@ -131,6 +146,10 @@
         <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
                 <tr>
+                    <th class="px-3 py-3 w-10">
+                        <input type="checkbox" id="select-all" onchange="toggleSelectAll(this)"
+                            class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                    </th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Invoice #</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Customer</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Date</th>
@@ -143,7 +162,12 @@
             </thead>
             <tbody class="bg-white divide-y divide-gray-100">
                 {% for inv in invoices %}
-                <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location='{% url 'owner_invoice_detail' invoice_id=inv.id %}'">
+                <tr class="hover:bg-gray-50 cursor-pointer" onclick="if(!event.target.closest('.no-nav'))window.location='{% url 'owner_invoice_detail' invoice_id=inv.id %}'">
+                    <td class="px-3 py-4 no-nav" onclick="event.stopPropagation()">
+                        <input type="checkbox" name="invoice_select" value="{{ inv.id }}"
+                            onchange="updateBatchBar()"
+                            class="invoice-checkbox rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                    </td>
                     <td class="px-6 py-4 whitespace-nowrap">
                         <span class="text-sm font-semibold text-blue-600 hover:text-blue-800">{{ inv.invoice_number }}</span>
                     </td>
@@ -212,6 +236,64 @@
 
 {% block extra_js %}
 <script>
+function toggleSelectAll(el) {
+    document.querySelectorAll('.invoice-checkbox').forEach(cb => { cb.checked = el.checked; });
+    updateBatchBar();
+}
+
+function updateBatchBar() {
+    const checked = document.querySelectorAll('.invoice-checkbox:checked');
+    const bar = document.getElementById('batch-bar');
+    const count = document.getElementById('selected-count');
+    if (checked.length > 0) {
+        bar.classList.remove('hidden');
+        count.textContent = checked.length;
+    } else {
+        bar.classList.add('hidden');
+    }
+    // Update select-all state
+    const all = document.querySelectorAll('.invoice-checkbox');
+    const selectAll = document.getElementById('select-all');
+    if (selectAll) {
+        selectAll.checked = all.length > 0 && checked.length === all.length;
+        selectAll.indeterminate = checked.length > 0 && checked.length < all.length;
+    }
+}
+
+function clearSelection() {
+    document.querySelectorAll('.invoice-checkbox').forEach(cb => { cb.checked = false; });
+    const selectAll = document.getElementById('select-all');
+    if (selectAll) selectAll.checked = false;
+    updateBatchBar();
+}
+
+function sendSelectedEmails() {
+    const ids = Array.from(document.querySelectorAll('.invoice-checkbox:checked')).map(cb => parseInt(cb.value));
+    if (!ids.length) return;
+    if (!confirm(`Send invoice emails for ${ids.length} invoice(s)?`)) return;
+
+    const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
+        document.cookie.split(';').find(c => c.trim().startsWith('csrftoken='))?.split('=')[1];
+
+    fetch('/api/billing/invoices/send-email-batch/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
+        body: JSON.stringify({ invoice_ids: ids }),
+    })
+    .then(r => r.json())
+    .then(data => {
+        if (data.success) {
+            const msg = `Sent: ${data.sent}` + (data.failed > 0 ? `, Failed: ${data.failed}` : '');
+            alert(msg);
+            clearSelection();
+            window.location.reload();
+        } else {
+            alert(data.error || 'Failed to send emails');
+        }
+    })
+    .catch(err => alert('Error: ' + err.message));
+}
+
 function createInvoice(customerId, customerName) {
     if (!confirm(`Create invoice for all uninvoiced repairs for ${customerName}?`)) return;
 
@@ -224,7 +306,7 @@ function createInvoice(customerId, customerName) {
             'Content-Type': 'application/json',
             'X-CSRFToken': csrfToken,
         },
-        body: JSON.stringify({ all_uninvoiced: true }),
+        body: JSON.stringify({ all_uninvoiced: true, auto_email: true }),
     })
     .then(r => {
         if (!r.ok) {


### PR DESCRIPTION
## What

### Fix: Auto-email on invoice creation
The "Create Invoice" button was sending `{ all_uninvoiced: true }` but the backend only sends email when `auto_email: true` is included. Added it — customers now actually receive the invoice email when you click Create Invoice.

### New: Batch email send from invoice list
- Checkboxes on every invoice row (clicking checkbox doesn't navigate to detail)
- Select All checkbox in the header
- Blue sticky action bar appears when invoices are selected with count + **Send Email** button
- New API endpoints:
  - `POST /api/billing/invoices/<id>/send-email/` — single invoice
  - `POST /api/billing/invoices/send-email-batch/` — multiple at once
- Shows results: "Sent: 3, Failed: 0"

### Docs: Custom contact email
Added to `FUTURE_FEATURES.md` — payment-complete and payment-cancelled pages currently show `info@rockstarwindshield.repair` (send-only). Waiting on Drake to set up a real reply-to address.

## Files Changed
| File | Change |
|------|--------|
| `apps/billing/urls.py` | Two new endpoints |
| `apps/billing/views.py` | `send_invoice_email` + `send_invoice_email_batch` views |
| `templates/saas/owner_invoices.html` | Checkboxes, batch bar, auto_email in JS |
| `docs/development/FUTURE_FEATURES.md` | Custom contact email todo |