### PR TITLE
feat: Auto-email + batch send + email fixes

### DIFF
--- a/apps/billing/services/invoice_email_service.py
+++ b/apps/billing/services/invoice_email_service.py
@@ -9,6 +9,7 @@ Sends invoice emails with:
 Author: Amelia (Clawdbot AI)
 Created: 2026-01-27
 """
+from __future__ import annotations
 
 import io
 import os
@@ -21,7 +22,6 @@ from django.conf import settings
 from django.core.mail import EmailMessage
 from django.utils import timezone
 
-from apps.billing.services.invoice_service import InvoiceService, InvoiceData
 from apps.technician_portal.models import Repair
 
 
@@ -47,6 +47,7 @@ class InvoiceEmailService:
     """
     
     def __init__(self):
+        from apps.billing.services.invoice_service import InvoiceService
         self.invoice_service = InvoiceService()
         self._setup_s3_client()
     
@@ -140,7 +141,7 @@ class InvoiceEmailService:
         
         return attachments
     
-    def _build_email_body(self, invoice_data: InvoiceData, include_photos: bool,
+    def _build_email_body(self, invoice_data, include_photos: bool,
                           payment_link: str = None) -> str:
         """Build the email body text"""
         lines = [

--- a/apps/billing/services/invoice_storage_service.py
+++ b/apps/billing/services/invoice_storage_service.py
@@ -9,6 +9,7 @@ Saves generated invoices to S3 for:
 Author: Amelia (Clawdbot AI)
 Created: 2026-01-27
 """
+from __future__ import annotations
 
 import os
 import json
@@ -20,7 +21,7 @@ import boto3
 from botocore.exceptions import ClientError
 from django.utils import timezone
 
-from apps.billing.services.invoice_service import InvoiceData
+# InvoiceData imported lazily to avoid reportlab dependency at module load
 
 
 # S3 path structure: invoices/{customer_id}/{year}/{invoice_number}.pdf

--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -307,6 +307,9 @@ def send_invoice_email(request, invoice_id):
     if not invoice.customer.email:
         return JsonResponse({'error': f'No email address for {invoice.customer.name}'}, status=400)
 
+    if invoice.status == 'PAID':
+        return JsonResponse({'error': f'Invoice {invoice.invoice_number} is already paid'}, status=400)
+
     try:
         from apps.billing.services.invoice_email_service import InvoiceEmailService
         email_svc = InvoiceEmailService()
@@ -347,6 +350,9 @@ def send_invoice_email_batch(request):
     for inv_id in invoice_ids:
         try:
             invoice = Invoice.objects.get(id=inv_id, tenant=tenant)
+            if invoice.status == 'PAID':
+                results.append({'id': inv_id, 'success': False, 'error': 'Already paid'})
+                continue
             if not invoice.customer.email:
                 results.append({'id': inv_id, 'success': False, 'error': 'No email'})
                 continue


### PR DESCRIPTION
## Changes

### feat: Auto-email on invoice creation + batch email send
- Create Invoice now passes `auto_email: true` — customers actually receive the email
- Checkboxes on invoice table rows with Select All
- Sticky blue action bar: select invoices → Send Email (batch)
- New endpoints: `POST /api/billing/invoices/<id>/send-email/` and `POST /api/billing/invoices/send-email-batch/`

### fix: Lazy import InvoiceService in email + storage services
Same reportlab crash as before — `invoice_email_service.py` and `invoice_storage_service.py` had top-level imports of `InvoiceService` which pulls in reportlab. Moved to lazy imports.

### fix: Block emailing paid invoices
Single and batch email endpoints return error for PAID invoices. Receipt emails can be added later.

### docs: Custom contact email
Added to `FUTURE_FEATURES.md` — payment pages show send-only email, needs real reply-to address.