### PR TITLE
Fix: Overdue badge now checks due_date correctly

### DIFF
--- a/apps/billing/services/invoice_service.py
+++ b/apps/billing/services/invoice_service.py
@@ -485,35 +485,42 @@ class InvoiceService:
         
         story = []
         
-        # Logo (if available)
-        logo = self._get_logo_for_pdf()
-        if logo:
-            story.append(logo)
-            story.append(Spacer(1, 10))
+        # Header: Logo + Company Name side by side
+        logo = self._get_logo_for_pdf(max_width=1.5*inch, max_height=1*inch)
         
-        # Header / Company Name (only if no logo, or as subtitle)
-        if not logo:
-            story.append(Paragraph(
-                f"<b>{self.COMPANY_NAME}</b>",
-                self.styles['InvoiceTitle']
-            ))
-        
-        # Company contact info
-        contact_parts = []
-        if self.COMPANY_PHONE:
-            contact_parts.append(self.COMPANY_PHONE)
-        if self.COMPANY_EMAIL:
-            contact_parts.append(self.COMPANY_EMAIL)
-        if self.COMPANY_WEBSITE:
-            contact_parts.append(self.COMPANY_WEBSITE)
+        # Build company info block (stacked vertically)
+        company_info_parts = [f"<b>{self.COMPANY_NAME}</b>"]
         if self.COMPANY_ADDRESS:
-            contact_parts.append(self.COMPANY_ADDRESS)
-            
-        if contact_parts:
-            story.append(Paragraph(
-                ' | '.join(contact_parts),
-                self.styles['CompanyInfo']
-            ))
+            # Split address into lines if it contains commas or newlines
+            addr = self.COMPANY_ADDRESS.replace('\n', '<br/>')
+            company_info_parts.append(addr)
+        if self.COMPANY_PHONE:
+            company_info_parts.append(self.COMPANY_PHONE)
+        if self.COMPANY_EMAIL:
+            company_info_parts.append(self.COMPANY_EMAIL)
+        if self.COMPANY_WEBSITE:
+            company_info_parts.append(self.COMPANY_WEBSITE)
+        
+        company_info_text = '<br/>'.join(company_info_parts)
+        company_info_para = Paragraph(company_info_text, self.styles['CompanyInfo'])
+        
+        if logo:
+            # Logo on left, company info on right
+            header_table = Table(
+                [[logo, company_info_para]],
+                colWidths=[1.8*inch, 5.2*inch]
+            )
+            header_table.setStyle(TableStyle([
+                ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+                ('ALIGN', (0, 0), (0, 0), 'LEFT'),
+                ('ALIGN', (1, 0), (1, 0), 'LEFT'),
+                ('LEFTPADDING', (0, 0), (-1, -1), 0),
+                ('RIGHTPADDING', (0, 0), (-1, -1), 0),
+            ]))
+            story.append(header_table)
+        else:
+            # No logo - just company info
+            story.append(company_info_para)
         
         story.append(Spacer(1, 20))
         

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -310,7 +310,13 @@ def _get_billing_context(tenant):
         )
         outstanding_amount = (total_outstanding.get('total') or Decimal('0.00'))
 
-        overdue_count = outstanding.filter(status='OVERDUE').count()
+        # Count overdue: either status=OVERDUE or due_date passed and not paid
+        from django.utils import timezone
+        today = timezone.now().date()
+        overdue_count = outstanding.filter(
+            models.Q(status='OVERDUE') | 
+            models.Q(due_date__lt=today, status__in=['SENT', 'PARTIAL'])
+        ).count()
 
         # Recent payments (last 10)
         recent_payments = Payment.objects.filter(


### PR DESCRIPTION
The dashboard overdue badge was only looking at `status='OVERDUE'`, but invoices don't auto-update to that status when they pass due date.

**Fix:** Now checks:
- Status is OVERDUE, **OR**
- Due date has passed AND status is SENT/PARTIAL

This ensures the overdue count is accurate without needing a background job to update invoice statuses.