### PR TITLE
feat: Send Reminder modal + email improvements

### DIFF
--- a/BILLING_ROADMAP.md
+++ b/BILLING_ROADMAP.md
@@ -127,11 +127,19 @@
 - [x] Owner can click "Send Reminder" on any overdue/outstanding invoice
 - [x] Reminder button on invoice detail page (`/owner/invoices/<id>/`)
 - [x] Sends appropriate email (overdue vs due_soon) based on invoice status
+- [x] **PDF invoice attached** to reminder emails
+- [x] Subject format: `[RS Systems] Overdue Notice: Invoice X - Customer`
+- [x] "Do not reply" footer (no inbound email configured)
 - [x] Reminder logged in invoice internal_notes
 - [ ] Auto-reminders: configurable schedule (7 days, 14 days, 30 days overdue)
 - [ ] Reminder count tracked per invoice
 
 **Note**: 5.3 deferred. Auto-reminders for Phase 6.
+
+### Email Configuration
+- **From**: Uses `DEFAULT_FROM_EMAIL` env var (default: `notifications@rockstarwindshield.repair`)
+- **Replies**: Not supported — emails include "do not reply" notice
+- **Future**: Consider Google Workspace or SendGrid Inbound Parse for reply handling
 
 ---
 

--- a/apps/billing/services/reminder_service.py
+++ b/apps/billing/services/reminder_service.py
@@ -33,9 +33,10 @@ class ReminderService:
     
     def __init__(self, tenant=None):
         self.tenant = tenant
+        # Use noreply email - replies won't be received
         self.from_email = getattr(
-            settings, 'INVOICE_FROM_EMAIL', 
-            'billing@rockstarwindshield.repair'
+            settings, 'REMINDER_FROM_EMAIL',
+            getattr(settings, 'DEFAULT_FROM_EMAIL', 'noreply@rockstarwindshield.repair')
         )
     
     def _filter(self, qs):
@@ -46,7 +47,7 @@ class ReminderService:
     
     def send_reminder(self, invoice, reminder_type='overdue'):
         """
-        Send a payment reminder for an invoice.
+        Send a payment reminder for an invoice with PDF attached.
         
         Args:
             invoice: Invoice model instance
@@ -61,13 +62,28 @@ class ReminderService:
         # Build email content
         subject, body = self._build_reminder_email(invoice, reminder_type)
         
+        # Generate PDF attachment
+        pdf_bytes = None
+        try:
+            from apps.billing.services.invoice_service import InvoiceService
+            invoice_service = InvoiceService()
+            repair_ids = list(invoice.line_items.exclude(repair_id__isnull=True).values_list('repair_id', flat=True))
+            pdf_bytes, _ = invoice_service.generate_invoice(
+                customer_id=invoice.customer_id,
+                repair_ids=repair_ids if repair_ids else None,
+            )
+        except Exception as e:
+            logger.warning(f"Could not generate PDF for reminder: {e}")
+            # Continue without PDF - still send the reminder
+        
         # Send via SendGrid or Django's email backend
         try:
             success = self._send_email(
                 to_email=invoice.customer.email,
                 subject=subject,
                 body=body,
-                invoice=invoice
+                invoice=invoice,
+                pdf_attachment=pdf_bytes
             )
             
             if success:
@@ -216,16 +232,18 @@ Rockstar Windshield Repair
     def _build_reminder_email(self, invoice, reminder_type):
         """Build reminder email subject and body."""
         
+        customer_name = invoice.customer.name
+        
         if reminder_type.startswith('due_soon'):
             days = reminder_type.split('_')[-1]
-            subject = f"Payment Reminder - Invoice {invoice.invoice_number} Due Soon"
+            subject = f"[RS Systems] Payment Reminder: Invoice {invoice.invoice_number} - {customer_name}"
             urgency = "friendly"
         elif reminder_type.startswith('overdue'):
             days = reminder_type.split('_')[-1]
-            subject = f"Overdue Notice - Invoice {invoice.invoice_number}"
+            subject = f"[RS Systems] Overdue Notice: Invoice {invoice.invoice_number} - {customer_name}"
             urgency = "urgent" if '30d' in reminder_type else "firm"
         else:
-            subject = f"Payment Reminder - Invoice {invoice.invoice_number}"
+            subject = f"[RS Systems] Payment Reminder: Invoice {invoice.invoice_number} - {customer_name}"
             urgency = "friendly"
         
         # Build body
@@ -274,18 +292,27 @@ Thank you for your business.
 
 Best regards,
 Rockstar Windshield Repair
-Phone: (555) 123-4567
-Email: billing@rockstarwindshield.repair
+
+---
+This is an automated message. Please do not reply to this email.
+For questions, call us or visit our website.
 """
         
         body = f"{greeting}\n{intro}\n{details}\n{payment_info}\n{closing}"
         
         return subject, body
     
-    def _send_email(self, to_email, subject, body, invoice=None):
+    def _send_email(self, to_email, subject, body, invoice=None, pdf_attachment=None):
         """
         Send email via SendGrid or Django's email backend.
         
+        Args:
+            to_email: Recipient email
+            subject: Email subject
+            body: Plain text body
+            invoice: Invoice object (for PDF filename)
+            pdf_attachment: PDF bytes to attach
+            
         Returns:
             bool: True if sent successfully
         """
@@ -295,7 +322,8 @@ Email: billing@rockstarwindshield.repair
         if sendgrid_key:
             try:
                 from sendgrid import SendGridAPIClient
-                from sendgrid.helpers.mail import Mail
+                from sendgrid.helpers.mail import Mail, Attachment, FileContent, FileName, FileType, Disposition
+                import base64
                 
                 message = Mail(
                     from_email=self.from_email,
@@ -303,6 +331,17 @@ Email: billing@rockstarwindshield.repair
                     subject=subject,
                     plain_text_content=body
                 )
+                
+                # Attach PDF if provided
+                if pdf_attachment and invoice:
+                    encoded_pdf = base64.b64encode(pdf_attachment).decode()
+                    attachment = Attachment(
+                        FileContent(encoded_pdf),
+                        FileName(f"Invoice_{invoice.invoice_number}.pdf"),
+                        FileType('application/pdf'),
+                        Disposition('attachment')
+                    )
+                    message.attachment = attachment
                 
                 sg = SendGridAPIClient(sendgrid_key)
                 response = sg.send(message)
@@ -315,15 +354,20 @@ Email: billing@rockstarwindshield.repair
         
         # Fallback to Django's email backend
         try:
-            from django.core.mail import send_mail
+            from django.core.mail import EmailMessage
             
-            send_mail(
+            email = EmailMessage(
                 subject=subject,
-                message=body,
+                body=body,
                 from_email=self.from_email,
-                recipient_list=[to_email],
-                fail_silently=False,
+                to=[to_email],
             )
+            
+            # Attach PDF if provided
+            if pdf_attachment and invoice:
+                email.attach(f"Invoice_{invoice.invoice_number}.pdf", pdf_attachment, 'application/pdf')
+            
+            email.send(fail_silently=False)
             return True
             
         except Exception as e:

--- a/apps/billing/services/reminder_service.py
+++ b/apps/billing/services/reminder_service.py
@@ -287,16 +287,39 @@ Or contact us to arrange alternative payment methods.
 Please contact us to arrange payment or if you have any questions.
 """
         
-        closing = """
-Thank you for your business.
-
-Best regards,
-Rockstar Windshield Repair
-
----
-This is an automated message. Please do not reply to this email.
-For questions, call us or visit our website.
-"""
+        # Get company info from BillingConfig
+        company_name = "Rockstar Windshield Repair"
+        company_phone = ""
+        company_website = ""
+        try:
+            from apps.billing.models import BillingConfig
+            config = BillingConfig.objects.first()
+            if config:
+                company_name = config.company_name or company_name
+                company_phone = config.company_phone or ""
+                company_website = config.company_website or ""
+        except Exception:
+            pass
+        
+        # Build closing with actual company info
+        closing_lines = [
+            "",
+            "Thank you for your business.",
+            "",
+            "Best regards,",
+            company_name,
+        ]
+        if company_phone:
+            closing_lines.append(f"Phone: {company_phone}")
+        if company_website:
+            closing_lines.append(company_website)
+        closing_lines.extend([
+            "",
+            "---",
+            "This is an automated message. Please do not reply to this email.",
+        ])
+        
+        closing = "\n".join(closing_lines)
         
         body = f"{greeting}\n{intro}\n{details}\n{payment_info}\n{closing}"
         

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -16,11 +16,16 @@ All notable changes to the RS Systems windshield repair management platform.
 
 ### Added — Send Reminder Button
 - **Send Reminder** button on invoice detail page now functional
-- Sends payment reminder email to customer (overdue or due_soon based on status)
+- **Polished modal** with invoice summary, email preview, and confirmation
+  - Shows customer, amount due, due date, status
+  - Email subject and body preview
+  - Lists what's included (PDF, payment link, invoice details)
+  - Warning if no email on file
+  - Escape key or click outside to close
 - **PDF invoice attached** to reminder emails
+- **Company info from BillingConfig** (no more hardcoded placeholders)
 - Subject format: `[RS Systems] Overdue Notice: Invoice X - Customer`
-- "Do not reply" footer added (no inbound email configured)
-- Confirmation prompt before sending
+- "Do not reply" footer added
 - Reminder logged in invoice internal_notes
 - URL: `POST /owner/invoices/<id>/reminder/`
 

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to the RS Systems windshield repair management platform.
 ### Added — Send Reminder Button
 - **Send Reminder** button on invoice detail page now functional
 - Sends payment reminder email to customer (overdue or due_soon based on status)
+- **PDF invoice attached** to reminder emails
+- Subject format: `[RS Systems] Overdue Notice: Invoice X - Customer`
+- "Do not reply" footer added (no inbound email configured)
 - Confirmation prompt before sending
 - Reminder logged in invoice internal_notes
 - URL: `POST /owner/invoices/<id>/reminder/`

--- a/templates/saas/owner_invoice_detail.html
+++ b/templates/saas/owner_invoice_detail.html
@@ -35,12 +35,9 @@
             </button>
         </form>
         {% if invoice.status != 'PAID' and invoice.status != 'CANCELLED' and invoice.status != 'DRAFT' %}
-        <form method="post" action="{% url 'owner_send_reminder' invoice_id=invoice.id %}" class="inline" onsubmit="return confirm('Send payment reminder to {{ invoice.customer.email }}?')">
-            {% csrf_token %}
-            <button type="submit" class="inline-flex items-center px-3 py-2 text-sm font-medium text-amber-700 bg-amber-50 border border-amber-300 rounded-lg hover:bg-amber-100 transition-colors">
-                <i class="fas fa-bell mr-2"></i>Send Reminder
-            </button>
-        </form>
+        <button onclick="openReminderModal()" class="inline-flex items-center px-3 py-2 text-sm font-medium text-amber-700 bg-amber-50 border border-amber-300 rounded-lg hover:bg-amber-100 transition-colors">
+            <i class="fas fa-bell mr-2"></i>Send Reminder
+        </button>
         {% endif %}
         {% endif %}
     </div>
@@ -346,4 +343,162 @@
         {% endif %}
     </div>
 </div>
+
+<!-- Send Reminder Modal -->
+{% if invoice.status != 'PAID' and invoice.status != 'CANCELLED' and invoice.status != 'DRAFT' %}
+<div id="reminder-modal" class="hidden fixed inset-0 z-50 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:p-0">
+        <!-- Background overlay -->
+        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="closeReminderModal()"></div>
+
+        <!-- Modal panel -->
+        <div class="relative inline-block bg-white rounded-2xl text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full">
+            <!-- Header -->
+            <div class="bg-gradient-to-r from-amber-50 to-orange-50 px-6 py-4 border-b border-amber-100">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 bg-amber-100 rounded-xl flex items-center justify-center">
+                            <i class="fas fa-bell text-amber-600"></i>
+                        </div>
+                        <div>
+                            <h3 class="text-lg font-bold text-gray-900" id="modal-title">Send Payment Reminder</h3>
+                            <p class="text-sm text-gray-500">{{ invoice.invoice_number }}</p>
+                        </div>
+                    </div>
+                    <button onclick="closeReminderModal()" class="text-gray-400 hover:text-gray-600 transition-colors">
+                        <i class="fas fa-times text-lg"></i>
+                    </button>
+                </div>
+            </div>
+
+            <!-- Body -->
+            <div class="px-6 py-5 space-y-5">
+                <!-- Invoice Summary -->
+                <div class="bg-gray-50 rounded-xl p-4 border border-gray-100">
+                    <div class="grid grid-cols-2 gap-4 text-sm">
+                        <div>
+                            <span class="text-gray-500">Customer</span>
+                            <p class="font-semibold text-gray-900">{{ invoice.customer.name }}</p>
+                        </div>
+                        <div>
+                            <span class="text-gray-500">Amount Due</span>
+                            <p class="font-bold text-lg {% if invoice.status == 'OVERDUE' %}text-red-600{% else %}text-gray-900{% endif %}">${{ invoice.amount_due|floatformat:2 }}</p>
+                        </div>
+                        <div>
+                            <span class="text-gray-500">Due Date</span>
+                            <p class="font-medium {% if invoice.status == 'OVERDUE' %}text-red-600{% else %}text-gray-900{% endif %}">
+                                {{ invoice.due_date|date:"M d, Y" }}
+                                {% if invoice.status == 'OVERDUE' %}
+                                <span class="text-xs text-red-500 ml-1">(Overdue)</span>
+                                {% endif %}
+                            </p>
+                        </div>
+                        <div>
+                            <span class="text-gray-500">Status</span>
+                            <p class="font-medium">
+                                {% if invoice.status == 'OVERDUE' %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">Overdue</span>
+                                {% elif invoice.status == 'PARTIAL' %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">Partial</span>
+                                {% else %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Sent</span>
+                                {% endif %}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Email Preview -->
+                <div>
+                    <label class="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Email Preview</label>
+                    <div class="bg-white border border-gray-200 rounded-xl overflow-hidden">
+                        <div class="px-4 py-3 bg-gray-50 border-b border-gray-100">
+                            <div class="flex items-center gap-2 text-sm">
+                                <span class="text-gray-500">To:</span>
+                                <span class="font-medium text-gray-900">{{ invoice.customer.email|default:"No email on file" }}</span>
+                            </div>
+                            <div class="flex items-center gap-2 text-sm mt-1">
+                                <span class="text-gray-500">Subject:</span>
+                                <span class="font-medium text-gray-900">
+                                    {% if invoice.status == 'OVERDUE' %}
+                                    [RS Systems] Overdue Notice: {{ invoice.invoice_number }} - {{ invoice.customer.name }}
+                                    {% else %}
+                                    [RS Systems] Payment Reminder: {{ invoice.invoice_number }} - {{ invoice.customer.name }}
+                                    {% endif %}
+                                </span>
+                            </div>
+                        </div>
+                        <div class="px-4 py-3 text-sm text-gray-600">
+                            <p class="mb-2">Dear {{ invoice.customer.name }},</p>
+                            {% if invoice.status == 'OVERDUE' %}
+                            <p class="text-red-700">This is a reminder that invoice {{ invoice.invoice_number }} was due on {{ invoice.due_date|date:"F d, Y" }} and remains unpaid.</p>
+                            {% else %}
+                            <p>This is a friendly reminder that invoice {{ invoice.invoice_number }} is due on {{ invoice.due_date|date:"F d, Y" }}.</p>
+                            {% endif %}
+                            <p class="mt-2 text-gray-400 text-xs">+ Invoice details, payment link, and PDF attachment</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- What's Included -->
+                <div class="flex items-start gap-3 text-sm text-gray-600 bg-blue-50 rounded-lg p-3 border border-blue-100">
+                    <i class="fas fa-paperclip text-blue-500 mt-0.5"></i>
+                    <div>
+                        <span class="font-medium text-blue-900">Email includes:</span>
+                        <ul class="mt-1 space-y-0.5 text-blue-800">
+                            <li>• PDF invoice attached</li>
+                            <li>• Payment link (if Stripe enabled)</li>
+                            <li>• Full invoice details</li>
+                        </ul>
+                    </div>
+                </div>
+
+                {% if not invoice.customer.email %}
+                <div class="flex items-start gap-3 text-sm bg-red-50 rounded-lg p-3 border border-red-100">
+                    <i class="fas fa-exclamation-triangle text-red-500 mt-0.5"></i>
+                    <div class="text-red-800">
+                        <span class="font-medium">No email address on file.</span>
+                        <p class="mt-0.5">Add an email to this customer before sending a reminder.</p>
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+
+            <!-- Footer -->
+            <div class="bg-gray-50 px-6 py-4 border-t border-gray-100 flex flex-col sm:flex-row gap-3 sm:justify-end">
+                <button onclick="closeReminderModal()" class="w-full sm:w-auto px-4 py-2.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
+                    Cancel
+                </button>
+                <form method="post" action="{% url 'owner_send_reminder' invoice_id=invoice.id %}" class="w-full sm:w-auto">
+                    {% csrf_token %}
+                    <button type="submit" {% if not invoice.customer.email %}disabled{% endif %}
+                        class="w-full px-5 py-2.5 text-sm font-semibold text-white bg-amber-600 rounded-lg hover:bg-amber-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2">
+                        <i class="fas fa-paper-plane"></i>
+                        Send Reminder
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+function openReminderModal() {
+    document.getElementById('reminder-modal').classList.remove('hidden');
+    document.body.classList.add('overflow-hidden');
+}
+
+function closeReminderModal() {
+    document.getElementById('reminder-modal').classList.add('hidden');
+    document.body.classList.remove('overflow-hidden');
+}
+
+// Close on escape key
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        closeReminderModal();
+    }
+});
+</script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
Polished Send Reminder functionality with proper modal and email improvements.

## Changes

### Send Reminder Modal
- Replaced browser confirm() with polished modal
- Invoice summary: customer, amount due, due date, status badge
- Email preview: To, Subject, body snippet
- Shows what's included: PDF attachment, payment link, invoice details
- Warning state if no email on file (button disabled)
- Escape key to close, click outside to close

### Email Improvements
- PDF invoice attached to reminder emails
- Company info pulled from BillingConfig (no more hardcoded placeholders)
- Subject format: `[RS Systems] Overdue Notice: Invoice X - Customer`
- "Do not reply" footer added
- Uses DEFAULT_FROM_EMAIL instead of hardcoded billing@

## Files Changed
- `templates/saas/owner_invoice_detail.html` — Modal UI
- `apps/billing/services/reminder_service.py` — PDF attachment, email improvements
- `docs/development/CHANGELOG.md`
- `BILLING_ROADMAP.md`

Author: Amelia 🦾