### PR TITLE
feat: Phase 7 — SaaS subscription billing + usage enforcement

### DIFF
--- a/BILLING_ROADMAP.md
+++ b/BILLING_ROADMAP.md
@@ -242,12 +242,14 @@ Separate from customer billing — this is charging glass shops to use RS System
 - Owner billing page at `/owner/billing/`
 - Tenant webhook handler
 
-**Still needed:**
+**Still needed (Drake action):**
 - [ ] Create Stripe Products + Prices in Stripe Dashboard
 - [ ] Copy `stripe_price_id` / `stripe_annual_price_id` into SubscriptionPlan records
-- [ ] Wire up subscription checkout flow (owner upgrades/downgrades plan)
-- [ ] Handle subscription webhooks (invoice.paid, customer.subscription.updated/deleted)
-- [ ] Dunning — handle failed subscription payments gracefully
-- [ ] Usage enforcement — block actions when plan limits hit (repairs, techs, storage)
-- [ ] Trial expiration → prompt to upgrade
-- [ ] Billing portal link (Stripe Customer Portal for managing payment method/invoices)
+
+**Completed (Feb 10, 2026):**
+- [x] Wire up subscription checkout flow (owner upgrades/downgrades plan)
+- [x] Handle subscription webhooks (invoice.paid, customer.subscription.updated/deleted)
+- [x] Dunning — handle failed subscription payments gracefully (past_due banner + email)
+- [x] Usage enforcement — block actions when plan limits hit (repairs, techs, customers)
+- [x] Trial expiration → prompt to upgrade (expired + expiring banners)
+- [x] Billing portal link (Stripe Customer Portal for managing payment method/invoices)

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -819,6 +819,14 @@ def invite_member(request):
     last_name = request.POST.get('last_name', '').strip()
     role = request.POST.get('role', 'viewer')
 
+    # Usage limit check for technicians
+    if role == 'technician' and tenant:
+        from apps.tenants.services.usage_service import UsageService
+        can_add, limit_msg = UsageService(tenant).can_add_technician()
+        if not can_add:
+            messages.warning(request, limit_msg)
+            return redirect('owner_settings')
+
     # Ability checkboxes for technicians/managers
     can_repair = request.POST.get('can_repair') == 'on'
     can_replace = request.POST.get('can_replace') == 'on'

--- a/apps/technician_portal/views/customers.py
+++ b/apps/technician_portal/views/customers.py
@@ -22,6 +22,14 @@ def create_customer(request):
     """Create a new customer."""
     tenant = getattr(request, 'tenant', None)
 
+    # Usage limit check
+    if tenant:
+        from apps.tenants.services.usage_service import UsageService
+        can_create, limit_msg = UsageService(tenant).can_add_customer()
+        if not can_create:
+            messages.warning(request, limit_msg)
+            return redirect('technician_dashboard')
+
     if request.method == 'POST':
         form = CustomerForm(request.POST, tenant=tenant)
         if form.is_valid():

--- a/apps/technician_portal/views/repairs.py
+++ b/apps/technician_portal/views/repairs.py
@@ -254,6 +254,15 @@ def repair_detail(request, repair_id):
 @technician_required
 def create_repair(request):
     """Create a new single repair."""
+    # Usage limit check
+    tenant = getattr(request, 'tenant', None)
+    if tenant:
+        from apps.tenants.services.usage_service import UsageService
+        can_create, limit_msg = UsageService(tenant).can_create_repair()
+        if not can_create:
+            messages.warning(request, limit_msg)
+            return redirect('technician_dashboard')
+
     if request.method == 'POST':
         # Convert HEIC images to JPEG
         if 'damage_photo_before' in request.FILES:

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -341,3 +341,32 @@ Major architectural overhaul: one permission system, one base template, fixed si
 **Latest Version**: 2.2.0
 **Last Updated**: February 1, 2026
 **Status**: Production Ready ✅
+
+## [2.3.0] - February 10, 2026
+
+### Added — Phase 7: SaaS Subscription Billing Polish
+
+#### Usage Enforcement
+- **Repair creation limit** — blocks creating repairs when monthly limit reached
+- **Customer creation limit** — blocks adding customers when at plan limit
+- **Technician invite limit** — blocks inviting technicians when at seat limit
+- All limits show friendly message with upgrade CTA
+
+#### Subscription Status Banners
+- **Trial expiring soon** (≤7 days) — amber banner with upgrade CTA
+- **Trial expired** — red banner prompting upgrade
+- **Past due** — red banner prompting payment method update
+- **Canceled** — gray banner with reactivate option
+- Banners display for owners/managers across all pages
+
+#### Already Built (discovered during Phase 7)
+- Usage meters on owner dashboard (repairs/technicians/customers with progress bars)
+- Full subscription API (subscribe, update, cancel, reactivate, billing portal)
+- Stripe webhook handlers for subscription lifecycle
+- SubscriptionPlan model with limits and Stripe price IDs
+- UsageService for tracking usage vs limits
+
+### What's Needed to Go Live
+1. Create Stripe Products/Prices in Stripe Dashboard (Drake action)
+2. Copy `stripe_price_id` values into SubscriptionPlan records
+3. Set `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` env vars in production

--- a/templates/base_app.html
+++ b/templates/base_app.html
@@ -174,6 +174,72 @@
     </div>
     {% endif %}
 
+    <!-- Subscription Status Banners (owners/managers only) -->
+    {% if is_owner_or_manager and tenant %}
+    {% if tenant.subscription_status == 'past_due' %}
+    <div class="bg-red-600 text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+                <div class="flex items-center">
+                    <i class="fas fa-exclamation-triangle mr-2"></i>
+                    <span class="font-medium">Payment failed.</span>
+                    <span class="ml-1">Please update your payment method to avoid service interruption.</span>
+                </div>
+                <a href="{% url 'billing_settings' %}" class="bg-white text-red-600 px-4 py-1.5 rounded-lg text-sm font-medium hover:bg-red-50 transition-colors">
+                    Update Payment
+                </a>
+            </div>
+        </div>
+    </div>
+    {% elif tenant.subscription_status == 'canceled' %}
+    <div class="bg-gray-600 text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+                <div class="flex items-center">
+                    <i class="fas fa-info-circle mr-2"></i>
+                    <span>Your subscription is set to cancel at the end of the billing period.</span>
+                </div>
+                <a href="{% url 'billing_settings' %}" class="bg-white text-gray-600 px-4 py-1.5 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors">
+                    Reactivate
+                </a>
+            </div>
+        </div>
+    </div>
+    {% elif tenant.plan == 'trial' %}
+        {% if tenant.is_trial_expired %}
+    <div class="bg-red-600 text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+                <div class="flex items-center">
+                    <i class="fas fa-exclamation-circle mr-2"></i>
+                    <span class="font-medium">Your free trial has expired.</span>
+                    <span class="ml-1">Upgrade now to continue using RS Systems.</span>
+                </div>
+                <a href="{% url 'billing_settings' %}" class="bg-white text-red-600 px-4 py-1.5 rounded-lg text-sm font-medium hover:bg-red-50 transition-colors">
+                    Upgrade Now
+                </a>
+            </div>
+        </div>
+    </div>
+        {% elif tenant.trial_days_remaining <= 7 %}
+    <div class="bg-amber-500 text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+                <div class="flex items-center">
+                    <i class="fas fa-clock mr-2"></i>
+                    <span class="font-medium">Your free trial expires in {{ tenant.trial_days_remaining }} day{{ tenant.trial_days_remaining|pluralize }}.</span>
+                    <span class="ml-1">Upgrade now to keep your data.</span>
+                </div>
+                <a href="{% url 'billing_settings' %}" class="bg-white text-amber-600 px-4 py-1.5 rounded-lg text-sm font-medium hover:bg-amber-50 transition-colors">
+                    Upgrade Now
+                </a>
+            </div>
+        </div>
+    </div>
+        {% endif %}
+    {% endif %}
+    {% endif %}
+
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {% block content %}{% endblock %}
     </main>


### PR DESCRIPTION
## Phase 7: SaaS Subscription Billing

### Usage Enforcement
- **Repair creation limit** — blocks creating repairs when monthly limit reached
- **Customer creation limit** — blocks adding customers when at plan limit  
- **Technician invite limit** — blocks inviting technicians when at seat limit
- All limits show friendly message with upgrade CTA

### Subscription Status Banners
- **Trial expiring soon** (≤7 days) — amber banner with upgrade CTA
- **Trial expired** — red banner prompting upgrade
- **Past due** — red banner prompting payment method update
- **Canceled** — gray banner with reactivate option
- Banners display for owners/managers across all pages

### Backend (already existed)
- SubscriptionPlan model with limits + Stripe price ID fields
- SubscriptionService for create/update/cancel/reactivate
- Stripe webhook handlers for subscription lifecycle
- UsageService for tracking usage vs limits
- Billing portal redirect

### To Go Live (Drake action)
1. Create Stripe Products/Prices in Stripe Dashboard
2. Copy price IDs into SubscriptionPlan records
3. Set `STRIPE_WEBHOOK_SECRET` env var in production

---

Also includes from previous commits:
- Security fixes (SSL defaults, billing API role checks, removed /setup-database/)
- Test suite fixes (22 failures → 0)
