### PR TITLE
fix: Stripe Checkout Sessions + webhook handler

### DIFF
--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -593,19 +593,18 @@ def billing_update_plan(request):
         if tenant.stripe_subscription_id:
             result = svc.update_subscription(tenant, new_plan_slug)
             messages.success(request, f'Plan updated to {result["new_plan"]}!')
+            return redirect('billing_settings')
         else:
             result = svc.create_subscription(tenant, new_plan_slug)
-            if result.get('client_secret'):
-                messages.info(
-                    request,
-                    'Subscription created. Please complete payment via the billing portal.'
-                )
+            # Redirect to Stripe Checkout for payment
+            if result.get('checkout_url'):
+                return redirect(result['checkout_url'])
             else:
                 messages.success(request, f'Subscribed to {result["plan"]}!')
+                return redirect('billing_settings')
     except SubscriptionError as e:
         messages.error(request, str(e))
-
-    return redirect('billing_settings')
+        return redirect('billing_settings')
 
 
 @owner_or_manager_required

--- a/apps/tenants/services/subscription_service.py
+++ b/apps/tenants/services/subscription_service.py
@@ -94,50 +94,48 @@ class SubscriptionService:
                 tenant.stripe_customer_id = customer.id
                 logger.info(f"Created Stripe customer {customer.id} for tenant {tenant.slug}")
             
-            # Step 2: Create subscription
-            subscription = stripe.Subscription.create(
+            # Step 2: Create Stripe Checkout Session for subscription
+            # (Using Checkout instead of direct subscription creation due to 
+            # Stripe API change removing payment_intent from Invoice objects)
+            checkout_session = stripe.checkout.Session.create(
                 customer=customer.id,
-                items=[{'price': price_id}],
-                payment_behavior='default_incomplete',
-                expand=['latest_invoice.payment_intent'],
+                mode='subscription',
+                line_items=[{'price': price_id, 'quantity': 1}],
+                success_url=f"https://{settings.EB_HOSTNAME}/owner/billing/?success=true",
+                cancel_url=f"https://{settings.EB_HOSTNAME}/owner/billing/?canceled=true",
                 metadata={
                     'tenant_id': str(tenant.id),
                     'tenant_slug': tenant.slug,
                     'plan_slug': plan.slug,
                     'billing_period': billing_period,
                 },
+                subscription_data={
+                    'metadata': {
+                        'tenant_id': str(tenant.id),
+                        'tenant_slug': tenant.slug,
+                    }
+                },
             )
             
-            # Step 3: Update tenant
-            tenant.stripe_subscription_id = subscription.id
+            # Step 3: Update tenant with customer ID (subscription ID comes via webhook)
             tenant.plan = plan.slug
             tenant.subscription_plan = plan
-            tenant.subscription_status = subscription.status
             tenant.save(update_fields=[
-                'stripe_customer_id', 'stripe_subscription_id',
-                'plan', 'subscription_plan', 'subscription_status',
+                'stripe_customer_id', 'plan', 'subscription_plan',
             ])
             
             logger.info(
-                f"Created subscription {subscription.id} for tenant {tenant.slug} "
-                f"on plan {plan.name} ({billing_period})"
+                f"Created checkout session {checkout_session.id} for tenant {tenant.slug} "
+                f"to subscribe to {plan.name} ({billing_period})"
             )
             
-            # Return details the frontend needs to complete payment
-            result = {
-                'subscription_id': subscription.id,
-                'status': subscription.status,
+            # Return checkout URL for redirect
+            return {
+                'checkout_url': checkout_session.url,
+                'session_id': checkout_session.id,
                 'plan': plan.name,
                 'billing_period': billing_period,
             }
-            
-            # Include client_secret if payment needs confirmation
-            if subscription.status == 'incomplete':
-                invoice = subscription.latest_invoice
-                if invoice and invoice.payment_intent:
-                    result['client_secret'] = invoice.payment_intent.client_secret
-            
-            return result
             
         except stripe.error.CardError as e:
             logger.error(f"Card error creating subscription for {tenant.slug}: {e}")

--- a/apps/tenants/webhooks.py
+++ b/apps/tenants/webhooks.py
@@ -5,6 +5,7 @@ Processes Stripe webhook events to keep tenant subscription state
 in sync with Stripe. Verifies webhook signatures for security.
 
 Events handled:
+- checkout.session.completed — customer completed Stripe Checkout
 - invoice.paid — subscription payment successful
 - invoice.payment_failed — payment failed (past_due)
 - customer.subscription.updated — plan changes, renewals
@@ -85,6 +86,7 @@ def stripe_subscription_webhook(request):
     
     # Route to handler
     handlers = {
+        'checkout.session.completed': _handle_checkout_completed,
         'invoice.paid': _handle_invoice_paid,
         'invoice.payment_failed': _handle_invoice_payment_failed,
         'customer.subscription.updated': _handle_subscription_updated,
@@ -133,6 +135,52 @@ def _find_tenant_by_subscription_id(subscription_id):
 # ------------------------------------------------------------------
 # Event Handlers
 # ------------------------------------------------------------------
+
+def _handle_checkout_completed(session):
+    """
+    Handle checkout.session.completed — customer completed Stripe Checkout.
+    
+    This fires when a customer finishes the Checkout flow and payment succeeds.
+    We update the tenant with the subscription ID from the session.
+    """
+    customer_id = session.get('customer')
+    subscription_id = session.get('subscription')
+    
+    if not subscription_id:
+        # Not a subscription checkout (might be a one-time payment)
+        logger.debug(f"checkout.session.completed without subscription: {session.get('id')}")
+        return
+    
+    # Try to find tenant by customer ID
+    tenant = _find_tenant_by_customer_id(customer_id)
+    
+    # Fallback: check metadata for tenant_id
+    if not tenant:
+        metadata = session.get('metadata', {})
+        tenant_id = metadata.get('tenant_id')
+        if tenant_id:
+            try:
+                tenant = Tenant.objects.get(id=tenant_id)
+            except Tenant.DoesNotExist:
+                pass
+    
+    if not tenant:
+        logger.warning(
+            f"checkout.session.completed: No tenant found for customer {customer_id} "
+            f"or metadata tenant_id"
+        )
+        return
+    
+    # Update tenant with subscription info
+    tenant.stripe_subscription_id = subscription_id
+    tenant.subscription_status = 'active'
+    tenant.save(update_fields=['stripe_subscription_id', 'subscription_status'])
+    
+    logger.info(
+        f"checkout.session.completed: Tenant {tenant.slug} subscribed. "
+        f"Subscription: {subscription_id}"
+    )
+
 
 def _handle_invoice_paid(invoice):
     """

--- a/docs/STRIPE_SETUP.md
+++ b/docs/STRIPE_SETUP.md
@@ -1,0 +1,129 @@
+# Stripe Setup Guide
+
+> Last updated: February 11, 2026
+
+RS Systems uses Stripe for two separate billing flows:
+1. **Customer invoices** — charging your customers for windshield repairs
+2. **SaaS subscriptions** — charging glass shops for using RS Systems
+
+---
+
+## Quick Answers
+
+**Webhook destination name:** `RS Systems Subscriptions` (or anything descriptive)
+
+**Description:** Optional, but helpful: `Handles subscription lifecycle events for RS Systems SaaS billing`
+
+---
+
+## Test Mode Setup (Current)
+
+### 1. Products & Prices
+
+Create these products in Stripe Dashboard → Products:
+
+| Product Name | Monthly Price | What you get |
+|--------------|---------------|--------------|
+| RS Systems Starter | $49/month | `price_xxxxx` |
+| RS Systems Pro | $99/month | `price_xxxxx` |
+| RS Systems Enterprise | $249/month | `price_xxxxx` |
+
+**Where the price IDs go:** Django Admin → Subscription Plans → edit each plan → paste into "Stripe price id" field
+
+### 2. Webhook Endpoint
+
+**URL:** `https://rockstarwindshield.repair/api/tenants/webhooks/stripe/`
+
+**Events to listen for:**
+- `invoice.paid` — payment successful, activate/renew subscription
+- `invoice.payment_failed` — payment failed, mark as past_due
+- `customer.subscription.updated` — plan changed, period renewed
+- `customer.subscription.deleted` — subscription fully canceled
+
+**Signing secret:** Copy the `whsec_xxxxx` value and set as `STRIPE_WEBHOOK_SECRET` env var in AWS EB
+
+### 3. Environment Variables (AWS Elastic Beanstalk)
+
+```
+STRIPE_SECRET_KEY=sk_test_xxxxx        # Already set
+STRIPE_WEBHOOK_SECRET=whsec_xxxxx      # From webhook endpoint
+```
+
+---
+
+## Going Live Checklist
+
+When ready for production payments:
+
+### 1. Switch Stripe to Live Mode
+Toggle from "Test mode" to live in the Stripe Dashboard (top right)
+
+### 2. Create Live Products & Prices
+Recreate the same 3 products in live mode. You'll get NEW price IDs:
+
+| Product | Test Price ID | Live Price ID |
+|---------|---------------|---------------|
+| Starter | `price_test_xxx` | `price_live_xxx` |
+| Pro | `price_test_xxx` | `price_live_xxx` |
+| Enterprise | `price_test_xxx` | `price_live_xxx` |
+
+### 3. Update SubscriptionPlan Records
+In Django Admin, update each plan's "Stripe price id" with the LIVE price IDs
+
+### 4. Create Live Webhook Endpoint
+Same URL, same events, but in live mode:
+- URL: `https://rockstarwindshield.repair/api/tenants/webhooks/stripe/`
+- Events: `invoice.paid`, `invoice.payment_failed`, `customer.subscription.updated`, `customer.subscription.deleted`
+- Copy the new `whsec_xxxxx` signing secret
+
+### 5. Update Environment Variables
+In AWS EB Configuration → Environment properties:
+
+```
+STRIPE_SECRET_KEY=sk_live_xxxxx        # Live secret key
+STRIPE_WEBHOOK_SECRET=whsec_xxxxx      # Live webhook signing secret
+```
+
+### 6. Verify
+1. Deploy the EB environment to pick up new env vars
+2. Test a real subscription signup with a real card
+3. Check Stripe Dashboard → Webhooks for successful deliveries
+
+---
+
+## Webhook Security
+
+The webhook handler verifies signatures to prevent spoofed requests:
+- **With secret:** Validates `Stripe-Signature` header — secure ✅
+- **Without secret (DEBUG only):** Accepts unverified — INSECURE ⚠️
+- **Without secret (production):** Returns error — won't process events
+
+Location: `apps/tenants/webhooks.py`
+
+---
+
+## Troubleshooting
+
+### Webhook returns 400/500
+- Check `STRIPE_WEBHOOK_SECRET` is set correctly
+- Check the signing secret matches the endpoint (test vs live)
+- Check server logs: `eb logs` or CloudWatch
+
+### Subscription not updating
+- Verify webhook endpoint is receiving events (Stripe Dashboard → Webhooks → click endpoint → Recent events)
+- Check the event type is in our handled list
+- Check Django logs for errors
+
+### "Plan has no Stripe Price ID"
+- The SubscriptionPlan record is missing `stripe_price_id`
+- Go to Django Admin → Subscription Plans → add the price ID
+
+---
+
+## Related Files
+
+- Models: `apps/tenants/models.py` (SubscriptionPlan, Tenant)
+- Service: `apps/tenants/services/subscription_service.py`
+- Webhook: `apps/tenants/webhooks.py`
+- Views: `apps/tenants/views.py`
+- UI: `templates/saas/billing.html`

--- a/docs/STRIPE_SETUP.md
+++ b/docs/STRIPE_SETUP.md
@@ -35,6 +35,7 @@ Create these products in Stripe Dashboard → Products:
 **URL:** `https://rockstarwindshield.repair/api/tenants/webhooks/stripe/`
 
 **Events to listen for:**
+- `checkout.session.completed` — customer finished Checkout, activate subscription
 - `invoice.paid` — payment successful, activate/renew subscription
 - `invoice.payment_failed` — payment failed, mark as past_due
 - `customer.subscription.updated` — plan changed, period renewed


### PR DESCRIPTION
## Fixes Stripe API Breaking Change

### Issue
Stripe removed `payment_intent` from Invoice objects (March 2025 breaking change), causing 500 errors when trying to create subscriptions.

### Solution
- Switched from direct subscription creation to **Stripe Checkout Sessions**
- User clicks 'Upgrade' → redirects to Stripe-hosted payment page → returns to site
- Added `checkout.session.completed` webhook handler to capture subscription ID

### Changes
- `apps/tenants/services/subscription_service.py` — use Checkout Sessions
- `apps/saas/views.py` — redirect to checkout URL
- `apps/tenants/webhooks.py` — handle checkout.session.completed
- `docs/STRIPE_SETUP.md` — updated event list

### Webhook Events Required
Make sure your Stripe webhook listens for:
- `checkout.session.completed` ← **NEW**
- `invoice.paid`
- `invoice.payment_failed`
- `customer.subscription.updated`
- `customer.subscription.deleted`