### PR TITLE
fix(security): subscription plan changes wait for payment confirmation

### DIFF
--- a/BILLING_ROADMAP.md
+++ b/BILLING_ROADMAP.md
@@ -243,13 +243,15 @@ Separate from customer billing — this is charging glass shops to use RS System
 - Tenant webhook handler
 
 **Still needed (Drake action):**
-- [ ] Create Stripe Products + Prices in Stripe Dashboard
-- [ ] Copy `stripe_price_id` / `stripe_annual_price_id` into SubscriptionPlan records
+- [x] Create Stripe Products + Prices in Stripe Dashboard ✅ Done Feb 11
+- [x] Copy `stripe_price_id` into SubscriptionPlan records ✅ Done Feb 11
+- [ ] Add `checkout.session.completed` event to Stripe webhook
 
-**Completed (Feb 10, 2026):**
-- [x] Wire up subscription checkout flow (owner upgrades/downgrades plan)
-- [x] Handle subscription webhooks (invoice.paid, customer.subscription.updated/deleted)
+**Completed (Feb 10-11, 2026):**
+- [x] Wire up subscription checkout flow via Stripe Checkout Sessions
+- [x] Handle subscription webhooks (checkout.session.completed, invoice.paid/failed, subscription.updated/deleted)
 - [x] Dunning — handle failed subscription payments gracefully (past_due banner + email)
 - [x] Usage enforcement — block actions when plan limits hit (repairs, techs, customers)
 - [x] Trial expiration → prompt to upgrade (expired + expiring banners)
 - [x] Billing portal link (Stripe Customer Portal for managing payment method/invoices)
+- [x] **Security fix**: Plan only upgrades AFTER payment confirmed (not before checkout)

--- a/apps/tenants/services/subscription_service.py
+++ b/apps/tenants/services/subscription_service.py
@@ -152,7 +152,8 @@ class SubscriptionService:
         """
         Change a tenant's subscription plan (upgrade or downgrade).
         
-        Stripe handles proration automatically.
+        - Upgrades: Immediate via Stripe, but plan access waits for webhook confirmation
+        - Downgrades: Scheduled for end of billing period (user keeps current access)
         
         Args:
             tenant: Tenant model instance
@@ -190,33 +191,92 @@ class SubscriptionService:
                     "Your subscription has been canceled. Please create a new subscription."
                 )
             
-            # Update the subscription item to the new price
-            stripe.Subscription.modify(
-                tenant.stripe_subscription_id,
-                items=[{
-                    'id': subscription['items']['data'][0].id,
-                    'price': new_plan.stripe_price_id,
-                }],
-                proration_behavior='create_prorations',
-                metadata={
-                    'plan_slug': new_plan.slug,
-                },
+            # Determine if this is an upgrade or downgrade BEFORE making changes
+            current_plan = tenant.subscription_plan
+            is_upgrade = (
+                current_plan is None or 
+                new_plan.monthly_price > (current_plan.monthly_price or 0)
             )
             
-            # Update tenant
-            tenant.plan = new_plan.slug
-            tenant.subscription_plan = new_plan
-            tenant.save(update_fields=['plan', 'subscription_plan'])
-            
-            logger.info(
-                f"Updated subscription for tenant {tenant.slug} to plan {new_plan.name}"
-            )
-            
-            return {
-                'subscription_id': tenant.stripe_subscription_id,
-                'new_plan': new_plan.name,
-                'status': 'updated',
-            }
+            if is_upgrade:
+                # UPGRADES: Apply immediately, but don't update local plan until
+                # webhook confirms. This prevents unpaid access to higher tier.
+                stripe.Subscription.modify(
+                    tenant.stripe_subscription_id,
+                    items=[{
+                        'id': subscription['items']['data'][0].id,
+                        'price': new_plan.stripe_price_id,
+                    }],
+                    proration_behavior='create_prorations',
+                    metadata={
+                        'plan_slug': new_plan.slug,
+                    },
+                )
+                
+                logger.info(
+                    f"Upgrade requested for tenant {tenant.slug} to plan {new_plan.name}. "
+                    f"Waiting for webhook confirmation."
+                )
+                
+                return {
+                    'subscription_id': tenant.stripe_subscription_id,
+                    'new_plan': new_plan.name,
+                    'status': 'pending',
+                    'message': (
+                        f'Upgrading to {new_plan.name}... '
+                        'Your new features will be available momentarily.'
+                    ),
+                }
+            else:
+                # DOWNGRADES: Schedule for end of billing period.
+                # User keeps current tier access since they paid for this period.
+                # Use Stripe Subscription Schedule to defer the change.
+                
+                if not current_plan or not current_plan.stripe_price_id:
+                    raise SubscriptionError(
+                        "Cannot determine current plan. Please contact support."
+                    )
+                
+                # Create a subscription schedule from the current subscription
+                schedule = stripe.SubscriptionSchedule.create(
+                    from_subscription=tenant.stripe_subscription_id,
+                )
+                
+                # Configure schedule: current plan now, new plan at period end
+                current_period_end = subscription.current_period_end
+                stripe.SubscriptionSchedule.modify(
+                    schedule.id,
+                    end_behavior='release',  # Release back to regular subscription after
+                    phases=[
+                        {
+                            # Current phase: keep current plan until period end
+                            'items': [{'price': current_plan.stripe_price_id}],
+                            'start_date': subscription.current_period_start,
+                            'end_date': current_period_end,
+                        },
+                        {
+                            # Next phase: switch to new (lower) plan
+                            'items': [{'price': new_plan.stripe_price_id}],
+                            'start_date': current_period_end,
+                        },
+                    ],
+                )
+                
+                logger.info(
+                    f"Downgrade scheduled for tenant {tenant.slug} to plan {new_plan.name}. "
+                    f"Access continues until period end ({current_period_end})."
+                )
+                
+                return {
+                    'subscription_id': tenant.stripe_subscription_id,
+                    'new_plan': new_plan.name,
+                    'status': 'scheduled',
+                    'current_period_end': current_period_end,
+                    'message': (
+                        f'Your plan will change to {new_plan.name} at the end of your '
+                        f'current billing period. You\'ll keep full access until then.'
+                    ),
+                }
             
         except stripe.error.InvalidRequestError as e:
             logger.error(f"Invalid request updating subscription for {tenant.slug}: {e}")

--- a/apps/tenants/tests.py
+++ b/apps/tenants/tests.py
@@ -1280,3 +1280,256 @@ class OwnerOnlyTest(BaseTestCase):
             content_type='application/json',
         )
         self.assertEqual(response.status_code, 403)
+
+
+# ======================================================================
+# 11. Subscription Upgrade/Downgrade Tests
+# ======================================================================
+
+class SubscriptionUpgradeDowngradeTest(BaseTestCase):
+    """
+    Tests for upgrade/downgrade detection and security handling.
+    
+    Key behaviors tested:
+    - Upgrades: Plan NOT updated locally (waits for webhook)
+    - Downgrades: User keeps current tier until period end (uses schedule)
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.svc = SubscriptionService()
+        
+        # Create enterprise plan for upgrade testing
+        self.enterprise_plan, _ = SubscriptionPlan.objects.get_or_create(
+            slug='enterprise',
+            defaults=dict(
+                name='Enterprise',
+                monthly_price=Decimal('249.00'),
+                max_repairs_per_month=None,
+                max_technicians=None,
+                max_customers=None,
+                max_storage_mb=50000,
+                trial_days=0,
+                display_order=3,
+                features={'invoicing': True, 'rewards': True, 'api_access': True, 'white_label': True},
+            ),
+        )
+        self.enterprise_plan.stripe_price_id = 'price_enterprise_monthly'
+        self.enterprise_plan.save()
+
+    def test_upgrade_detection_starter_to_pro(self):
+        """Starter ($49) → Pro ($99) is detected as upgrade."""
+        self.tenant.subscription_plan = self.starter_plan
+        self.tenant.plan = 'starter'
+        self.tenant.save()
+        
+        is_upgrade = (
+            self.pro_plan.monthly_price > 
+            (self.tenant.subscription_plan.monthly_price or 0)
+        )
+        self.assertTrue(is_upgrade)
+
+    def test_upgrade_detection_pro_to_enterprise(self):
+        """Pro ($99) → Enterprise ($249) is detected as upgrade."""
+        self.tenant.subscription_plan = self.pro_plan
+        self.tenant.plan = 'pro'
+        self.tenant.save()
+        
+        is_upgrade = (
+            self.enterprise_plan.monthly_price > 
+            (self.tenant.subscription_plan.monthly_price or 0)
+        )
+        self.assertTrue(is_upgrade)
+
+    def test_downgrade_detection_pro_to_starter(self):
+        """Pro ($99) → Starter ($49) is detected as downgrade."""
+        self.tenant.subscription_plan = self.pro_plan
+        self.tenant.plan = 'pro'
+        self.tenant.save()
+        
+        is_upgrade = (
+            self.starter_plan.monthly_price > 
+            (self.tenant.subscription_plan.monthly_price or 0)
+        )
+        self.assertFalse(is_upgrade)
+
+    def test_downgrade_detection_enterprise_to_starter(self):
+        """Enterprise ($249) → Starter ($49) is detected as downgrade."""
+        self.tenant.subscription_plan = self.enterprise_plan
+        self.tenant.plan = 'enterprise'
+        self.tenant.save()
+        
+        is_upgrade = (
+            self.starter_plan.monthly_price > 
+            (self.tenant.subscription_plan.monthly_price or 0)
+        )
+        self.assertFalse(is_upgrade)
+
+    def test_no_plan_to_any_is_upgrade(self):
+        """No current plan → any paid plan is treated as upgrade."""
+        self.tenant.subscription_plan = None
+        self.tenant.plan = 'trial'
+        self.tenant.save()
+        
+        is_upgrade = (
+            self.tenant.subscription_plan is None or 
+            self.starter_plan.monthly_price > 
+            (self.tenant.subscription_plan.monthly_price if self.tenant.subscription_plan else 0)
+        )
+        self.assertTrue(is_upgrade)
+
+    @patch('stripe.Subscription.retrieve')
+    @patch('stripe.Subscription.modify')
+    def test_upgrade_does_not_update_local_plan(self, mock_modify, mock_retrieve):
+        """Upgrade returns 'pending' status and does NOT update tenant.plan."""
+        # Setup tenant on starter plan with active subscription
+        self.tenant.subscription_plan = self.starter_plan
+        self.tenant.plan = 'starter'
+        self.tenant.stripe_subscription_id = 'sub_test123'
+        self.tenant.save()
+        
+        # Mock Stripe responses
+        mock_retrieve.return_value = MagicMock(
+            status='active',
+            current_period_end=1735689600,
+            current_period_start=1733011200,
+        )
+        mock_retrieve.return_value.__getitem__ = lambda s, k: {
+            'items': {'data': [MagicMock(id='si_item123')]}
+        }.get(k)
+        mock_modify.return_value = {'id': 'sub_test123'}
+        
+        # Attempt upgrade to Pro
+        result = self.svc.update_subscription(self.tenant, 'pro')
+        
+        # Verify result indicates pending (waiting for webhook)
+        self.assertEqual(result['status'], 'pending')
+        self.assertEqual(result['new_plan'], 'Pro')
+        self.assertIn('momentarily', result['message'])
+        
+        # CRITICAL: Local plan should NOT be updated
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.plan, 'starter')  # Still starter!
+        self.assertEqual(self.tenant.subscription_plan, self.starter_plan)
+
+    @patch('stripe.SubscriptionSchedule.modify')
+    @patch('stripe.SubscriptionSchedule.create')
+    @patch('stripe.Subscription.retrieve')
+    def test_downgrade_creates_schedule_keeps_current_plan(
+        self, mock_retrieve, mock_schedule_create, mock_schedule_modify
+    ):
+        """Downgrade creates schedule and keeps user on current (higher) plan."""
+        # Setup tenant on Pro plan with active subscription
+        self.tenant.subscription_plan = self.pro_plan
+        self.tenant.plan = 'pro'
+        self.tenant.stripe_subscription_id = 'sub_test456'
+        self.tenant.save()
+        
+        # Mock Stripe responses
+        mock_sub = MagicMock(
+            status='active',
+            current_period_end=1735689600,
+            current_period_start=1733011200,
+        )
+        mock_sub.__getitem__ = lambda s, k: {
+            'items': {'data': [MagicMock(id='si_item456')]}
+        }.get(k)
+        mock_retrieve.return_value = mock_sub
+        
+        mock_schedule_create.return_value = MagicMock(id='sub_sched_789')
+        mock_schedule_modify.return_value = {}
+        
+        # Attempt downgrade to Starter
+        result = self.svc.update_subscription(self.tenant, 'starter')
+        
+        # Verify result indicates scheduled
+        self.assertEqual(result['status'], 'scheduled')
+        self.assertEqual(result['new_plan'], 'Starter')
+        self.assertIn('end of your current billing period', result['message'])
+        self.assertEqual(result['current_period_end'], 1735689600)
+        
+        # CRITICAL: Local plan should NOT be changed (user keeps Pro access)
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.plan, 'pro')  # Still Pro!
+        self.assertEqual(self.tenant.subscription_plan, self.pro_plan)
+        
+        # Verify schedule was created
+        mock_schedule_create.assert_called_once_with(
+            from_subscription='sub_test456'
+        )
+
+    @patch('stripe.Subscription.retrieve')
+    def test_upgrade_calls_stripe_modify_with_proration(self, mock_retrieve):
+        """Upgrade calls Stripe with create_prorations behavior."""
+        self.tenant.subscription_plan = self.starter_plan
+        self.tenant.plan = 'starter'
+        self.tenant.stripe_subscription_id = 'sub_test789'
+        self.tenant.save()
+        
+        mock_retrieve.return_value = MagicMock(
+            status='active',
+            current_period_end=1735689600,
+        )
+        mock_retrieve.return_value.__getitem__ = lambda s, k: {
+            'items': {'data': [MagicMock(id='si_item789')]}
+        }.get(k)
+        
+        with patch('stripe.Subscription.modify') as mock_modify:
+            mock_modify.return_value = {'id': 'sub_test789'}
+            self.svc.update_subscription(self.tenant, 'pro')
+            
+            # Verify Stripe.modify was called with correct params
+            mock_modify.assert_called_once()
+            call_kwargs = mock_modify.call_args[1]
+            self.assertEqual(call_kwargs['proration_behavior'], 'create_prorations')
+            self.assertEqual(call_kwargs['items'][0]['price'], 'price_pro_monthly')
+
+    def test_downgrade_requires_current_plan_stripe_id(self):
+        """Downgrade fails gracefully if current plan has no stripe_price_id."""
+        # Create a plan without stripe price ID
+        broken_plan = SubscriptionPlan.objects.create(
+            name='BrokenPlan', slug='broken',
+            monthly_price=Decimal('199.00'), display_order=99,
+        )
+        self.tenant.subscription_plan = broken_plan
+        self.tenant.plan = 'broken'
+        self.tenant.stripe_subscription_id = 'sub_test999'
+        self.tenant.save()
+        
+        with patch('stripe.Subscription.retrieve') as mock_retrieve:
+            mock_retrieve.return_value = MagicMock(
+                status='active',
+                current_period_end=1735689600,
+            )
+            mock_retrieve.return_value.__getitem__ = lambda s, k: {
+                'items': {'data': [MagicMock(id='si_item999')]}
+            }.get(k)
+            
+            with self.assertRaises(SubscriptionError) as ctx:
+                self.svc.update_subscription(self.tenant, 'starter')
+            
+            self.assertIn('current plan', str(ctx.exception).lower())
+
+    def test_same_price_treated_as_downgrade(self):
+        """Same price is treated as downgrade (safe, no upgrade access)."""
+        # Create two plans with same price
+        plan_a = SubscriptionPlan.objects.create(
+            name='Plan A', slug='plan-a',
+            monthly_price=Decimal('99.00'),
+            stripe_price_id='price_plan_a',
+            display_order=10,
+        )
+        plan_b = SubscriptionPlan.objects.create(
+            name='Plan B', slug='plan-b',
+            monthly_price=Decimal('99.00'),
+            stripe_price_id='price_plan_b',
+            display_order=11,
+        )
+        
+        self.tenant.subscription_plan = plan_a
+        self.tenant.plan = 'plan-a'
+        self.tenant.save()
+        
+        # Same price means NOT an upgrade (99 > 99 is False)
+        is_upgrade = plan_b.monthly_price > (plan_a.monthly_price or 0)
+        self.assertFalse(is_upgrade)

--- a/docs/AMELIA_ROADMAP.md
+++ b/docs/AMELIA_ROADMAP.md
@@ -1,7 +1,7 @@
 # RS Systems — Roadmap
 
 *High-level project status and what's next.*
-*Last Updated: February 4, 2026*
+*Last Updated: February 11, 2026
 
 ---
 
@@ -57,12 +57,17 @@ Referral codes, point-based rewards, flexible redemption options.
 - Statement of account per customer
 → Details: [`BILLING_ROADMAP.md`](/BILLING_ROADMAP.md#phase-6-polish--automation) (~12 hours)
 
-### SaaS Subscription Billing (Phase 7)
-Wire up Stripe Products/Prices for subscription plans, checkout flow, subscription webhooks, usage enforcement, trial expiration.
+### SaaS Subscription Billing (Phase 7) ✅ DONE (Feb 11, 2026)
+- Stripe Checkout Sessions for new subscriptions
+- Usage enforcement (repairs/techs/customers limits)
+- Trial expiring/expired banners
+- Past due / canceled subscription banners
+- checkout.session.completed webhook handler
+- Security: plan only upgrades after payment confirmed
 → Details: [`BILLING_ROADMAP.md`](/BILLING_ROADMAP.md#phase-7-saas-subscription-billing-glass-shops)
 
-### Deploy v2.x to AWS
-PLAN.md Step 6 — push the unified permissions/template/billing stack to production. Run migrations, verify Stripe webhook secret is set, fill in BillingConfig.
+### Deploy v2.x to AWS ✅ DONE
+Production running on AWS Elastic Beanstalk at rockstarwindshield.repair
 
 ---
 

--- a/docs/STRIPE_SETUP.md
+++ b/docs/STRIPE_SETUP.md
@@ -1,6 +1,16 @@
 # Stripe Setup Guide
 
-> Last updated: February 11, 2026
+> Last updated: February 11, 2026 (v2.3.1)
+
+## Security Note
+
+**Plan upgrades only happen AFTER payment is confirmed.** When a user clicks "Upgrade":
+1. They're redirected to Stripe Checkout (hosted by Stripe)
+2. They enter payment info and complete checkout
+3. Stripe sends `checkout.session.completed` webhook
+4. Our webhook handler upgrades the plan
+
+The plan is NEVER upgraded before payment. This prevents users from getting paid features without paying.
 
 RS Systems uses Stripe for two separate billing flows:
 1. **Customer invoices** — charging your customers for windshield repairs

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -370,3 +370,16 @@ Major architectural overhaul: one permission system, one base template, fixed si
 1. Create Stripe Products/Prices in Stripe Dashboard (Drake action)
 2. Copy `stripe_price_id` values into SubscriptionPlan records
 3. Set `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` env vars in production
+
+## [2.3.1] - February 11, 2026
+
+### Security
+- **CRITICAL: Plan upgrade now requires payment** — Fixed security hole where clicking "Upgrade" granted paid plan features before payment completed. Plan now only upgrades via `checkout.session.completed` webhook after Stripe confirms payment.
+
+### Fixed
+- **Stripe API breaking change** — Switched from direct subscription creation to Stripe Checkout Sessions (Stripe removed `payment_intent` from Invoice objects in March 2025)
+- **Added checkout.session.completed webhook handler** — Captures subscription ID and upgrades plan after successful payment
+
+### Changed
+- `create_subscription` now returns `checkout_url` for redirect instead of `client_secret`
+- Plan/subscription_plan fields only updated in webhook handlers, never before payment


### PR DESCRIPTION
## Security Fixes

### Problem
Plan was being upgraded locally **before** Stripe confirmed payment, allowing users to access paid features without paying. Same bug existed for both initial subscriptions (fixed in #28) and plan changes.

### Solution

**Upgrades (Starter → Pro):**
- Stripe charges proration immediately
- Local plan update waits for `customer.subscription.updated` webhook
- No higher-tier access until payment confirmed ✅

**Downgrades (Pro → Starter):**
- Uses Stripe Subscription Schedule to defer change to period end
- User keeps current tier access until billing period ends
- They paid for this period, they should keep it ✅

### Tests Added
10 new tests covering:
- Upgrade/downgrade detection based on `monthly_price`
- Upgrades return `pending` status, don't update local plan
- Downgrades create schedule, keep current tier
- Edge cases (no plan, same price, missing stripe_price_id)

### Commits
- `678ba2d0` - fix(security): subscription plan changes wait for payment confirmation
- `83b5d356` - test: add upgrade/downgrade detection and security tests