### PR TITLE
fix(security): don't upgrade plan on incomplete subscription status

### DIFF
--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -468,8 +468,11 @@ def billing_view(request):
             if action == 'upgrade':
                 plan_slug = request.POST.get('plan')
                 if plan_slug:
-                    svc.create_subscription(tenant, plan_slug)
-                    messages.success(request, 'Subscription created! You may need to complete payment.')
+                    result = svc.create_subscription(tenant, plan_slug)
+                    # Redirect to Stripe Checkout for payment
+                    if result.get('checkout_url'):
+                        return redirect(result['checkout_url'])
+                    messages.success(request, 'Subscription created!')
             elif action == 'change_plan':
                 plan_slug = request.POST.get('plan')
                 if plan_slug:

--- a/apps/tenants/webhooks.py
+++ b/apps/tenants/webhooks.py
@@ -294,11 +294,24 @@ def _handle_subscription_updated(subscription):
         'past_due': 'past_due',
         'canceled': 'canceled',
         'trialing': 'trialing',
-        'incomplete': 'active',  # Payment in progress
+        'incomplete': 'incomplete',  # SECURITY: Don't treat as active until paid
         'incomplete_expired': 'expired',
         'unpaid': 'past_due',
     }
     new_status = status_map.get(stripe_status, tenant.subscription_status)
+    
+    # SECURITY: Only update plan if subscription is actually active (payment confirmed)
+    # 'incomplete' means checkout started but not paid — don't upgrade yet!
+    if stripe_status not in ('active', 'trialing'):
+        # Just update status, don't change plan
+        tenant.subscription_status = new_status
+        tenant.stripe_subscription_id = subscription_id
+        tenant.save(update_fields=['subscription_status', 'stripe_subscription_id'])
+        logger.info(
+            f"subscription.updated: Tenant {tenant.slug} status={new_status} "
+            f"(plan unchanged, waiting for payment)"
+        )
+        return
     
     # Check if plan changed (look at the price ID)
     items = subscription.get('items', {}).get('data', [])


### PR DESCRIPTION
## Root Cause Found

The `subscription.updated` webhook was mapping `incomplete` status to `active` and updating the plan when the Checkout **session** was created — before any payment!

```python
# OLD (broken)
'incomplete': 'active',  # Payment in progress
```

When user clicks upgrade:
1. Checkout session created → Stripe fires `subscription.updated` with status `incomplete`
2. Webhook mapped `incomplete` → `active` 
3. Webhook updated `tenant.plan` immediately
4. User got Pro features without paying 💀

## Fixes

**1. webhooks.py** - Only update plan when actually paid:
- `incomplete` stays as `incomplete`, not treated as `active`
- Early return if status not in (`active`, `trialing`) — just update status, don't change plan

**2. saas/views.py** - Redirect to Checkout:
- `billing_view` upgrade action now redirects to Stripe Checkout URL
- Was just showing success message without redirecting to payment page

## Testing
Upgrade flow should now:
1. Redirect to Stripe Checkout
2. Not update plan until payment succeeds
3. Webhook `checkout.session.completed` handles plan update after payment