### PR TITLE
fix: void incomplete subscriptions + redirect to Stripe for payment

### DIFF
--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -476,17 +476,28 @@ def billing_view(request):
             elif action == 'change_plan':
                 plan_slug = request.POST.get('plan')
                 if plan_slug:
-                    result = svc.update_subscription(tenant, plan_slug)
-                    if result.get('status') == 'pending':
-                        # Upgrade requires payment - redirect to Billing Portal
-                        messages.info(request, 'Complete payment in Stripe to activate your upgrade.')
-                        return_url = request.build_absolute_uri('/owner/billing/')
-                        portal_url = svc.create_billing_portal_session(tenant, return_url)
-                        return redirect(portal_url)
-                    elif result.get('status') == 'scheduled':
-                        messages.info(request, result.get('message', 'Plan change scheduled.'))
-                    else:
-                        messages.success(request, f'Plan updated to {result.get("new_plan")}!')
+                    try:
+                        if tenant.stripe_subscription_id:
+                            result = svc.update_subscription(tenant, plan_slug)
+                            if result.get('status') == 'pending':
+                                messages.info(request, 'Complete payment in Stripe to activate your upgrade.')
+                                return_url = request.build_absolute_uri('/owner/billing/')
+                                portal_url = svc.create_billing_portal_session(tenant, return_url)
+                                return redirect(portal_url)
+                            elif result.get('status') == 'scheduled':
+                                messages.info(request, result.get('message', 'Plan change scheduled.'))
+                            else:
+                                messages.success(request, f'Plan updated to {result.get("new_plan")}!')
+                        else:
+                            raise SubscriptionError("No subscription")
+                    except SubscriptionError as e:
+                        if 'canceled' in str(e).lower() or 'not completed' in str(e).lower() or 'no subscription' in str(e).lower():
+                            # Auto-fallback to create new subscription
+                            result = svc.create_subscription(tenant, plan_slug)
+                            if result.get('checkout_url'):
+                                return redirect(result['checkout_url'])
+                        else:
+                            raise
             elif action == 'cancel':
                 svc.cancel_subscription(tenant)
                 messages.success(request, 'Subscription will cancel at end of billing period.')
@@ -603,26 +614,34 @@ def billing_update_plan(request):
     svc = SubscriptionService()
     try:
         if tenant.stripe_subscription_id:
-            result = svc.update_subscription(tenant, new_plan_slug)
-            if result.get('status') == 'pending':
-                # Upgrade requires payment - redirect to Billing Portal
-                messages.info(request, 'Complete payment in Stripe to activate your upgrade.')
-                return_url = request.build_absolute_uri('/owner/billing/')
-                portal_url = svc.create_billing_portal_session(tenant, return_url)
-                return redirect(portal_url)
-            elif result.get('status') == 'scheduled':
-                messages.info(request, result.get('message', 'Plan change scheduled for end of billing period.'))
-            else:
-                messages.success(request, f'Plan updated to {result["new_plan"]}!')
-            return redirect('billing_settings')
-        else:
-            result = svc.create_subscription(tenant, new_plan_slug)
-            # Redirect to Stripe Checkout for payment
-            if result.get('checkout_url'):
-                return redirect(result['checkout_url'])
-            else:
-                messages.success(request, f'Subscribed to {result["plan"]}!')
+            try:
+                result = svc.update_subscription(tenant, new_plan_slug)
+                if result.get('status') == 'pending':
+                    # Upgrade requires payment - redirect to Billing Portal
+                    messages.info(request, 'Complete payment in Stripe to activate your upgrade.')
+                    return_url = request.build_absolute_uri('/owner/billing/')
+                    portal_url = svc.create_billing_portal_session(tenant, return_url)
+                    return redirect(portal_url)
+                elif result.get('status') == 'scheduled':
+                    messages.info(request, result.get('message', 'Plan change scheduled for end of billing period.'))
+                else:
+                    messages.success(request, f'Plan updated to {result["new_plan"]}!')
                 return redirect('billing_settings')
+            except SubscriptionError as e:
+                # If subscription was canceled/incomplete, auto-fallback to create new
+                if 'canceled' in str(e).lower() or 'not completed' in str(e).lower():
+                    # Fall through to create_subscription below
+                    pass
+                else:
+                    raise
+        
+        # Create new subscription (for trial users or after canceled sub)
+        result = svc.create_subscription(tenant, new_plan_slug)
+        if result.get('checkout_url'):
+            return redirect(result['checkout_url'])
+        else:
+            messages.success(request, f'Subscribed to {result["plan"]}!')
+            return redirect('billing_settings')
     except SubscriptionError as e:
         messages.error(request, str(e))
         return redirect('billing_settings')

--- a/apps/tenants/services/subscription_service.py
+++ b/apps/tenants/services/subscription_service.py
@@ -205,8 +205,11 @@ class SubscriptionService:
             subscription = stripe.Subscription.retrieve(tenant.stripe_subscription_id)
             
             if subscription.status in ('canceled', 'incomplete_expired'):
+                # Clear stale subscription ID and tell user to start fresh
+                tenant.stripe_subscription_id = ''
+                tenant.save(update_fields=['stripe_subscription_id'])
                 raise SubscriptionError(
-                    "Your subscription has been canceled. Please create a new subscription."
+                    "Previous subscription was canceled. Please select a plan to subscribe."
                 )
             
             # If subscription is incomplete (never paid), void it and start fresh

--- a/apps/tenants/services/subscription_service.py
+++ b/apps/tenants/services/subscription_service.py
@@ -78,6 +78,24 @@ class SubscriptionService:
             )
         
         try:
+            # Step 0: Void any incomplete subscriptions from previous attempts
+            # This prevents stale invoices piling up when users change their mind
+            if tenant.stripe_subscription_id:
+                try:
+                    old_sub = stripe.Subscription.retrieve(tenant.stripe_subscription_id)
+                    if old_sub.status in ('incomplete', 'incomplete_expired'):
+                        stripe.Subscription.delete(tenant.stripe_subscription_id)
+                        tenant.stripe_subscription_id = ''
+                        tenant.save(update_fields=['stripe_subscription_id'])
+                        logger.info(
+                            f"Voided incomplete subscription for tenant {tenant.slug} "
+                            f"before creating new checkout"
+                        )
+                except stripe.error.InvalidRequestError:
+                    # Subscription doesn't exist or already canceled
+                    tenant.stripe_subscription_id = ''
+                    tenant.save(update_fields=['stripe_subscription_id'])
+            
             # Step 1: Create or retrieve Stripe Customer
             if tenant.stripe_customer_id:
                 customer = stripe.Customer.retrieve(tenant.stripe_customer_id)
@@ -189,6 +207,19 @@ class SubscriptionService:
             if subscription.status in ('canceled', 'incomplete_expired'):
                 raise SubscriptionError(
                     "Your subscription has been canceled. Please create a new subscription."
+                )
+            
+            # If subscription is incomplete (never paid), void it and start fresh
+            if subscription.status == 'incomplete':
+                stripe.Subscription.delete(tenant.stripe_subscription_id)
+                tenant.stripe_subscription_id = ''
+                tenant.save(update_fields=['stripe_subscription_id'])
+                logger.info(
+                    f"Voided incomplete subscription for tenant {tenant.slug} "
+                    f"during plan change"
+                )
+                raise SubscriptionError(
+                    "Previous subscription was not completed. Please start a new subscription."
                 )
             
             # Determine if this is an upgrade or downgrade BEFORE making changes


### PR DESCRIPTION
**Fixes:**
- Void incomplete subscriptions before creating new ones (prevents stale invoices)
- Redirect to Stripe Billing Portal for upgrades requiring payment
- Show accurate status messages instead of lying 'Plan updated!'

**When user changes mind before paying:**
- Old incomplete subscription gets voided
- Start fresh with new plan selection