### PR TITLE
style: apply RS + Sparkle logo across all templates

### DIFF
--- a/templates/base_app.html
+++ b/templates/base_app.html
@@ -50,7 +50,11 @@
                 <div class="flex items-center space-x-6">
                     <a href="{% if is_owner_or_manager %}{% url 'owner_dashboard' %}{% else %}{% url 'technician_dashboard' %}{% endif %}" class="flex items-center space-x-2">
                         <div class="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
-                            <i class="fas fa-car-crash text-white text-sm"></i>
+                            <svg viewBox="0 0 40 40" class="w-5 h-5">
+                                <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                                <circle cx="32" cy="10" r="2" fill="white"/>
+                                <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                            </svg>
                         </div>
                         <span class="text-xl font-bold text-gray-900 hidden sm:inline">RS Systems</span>
                     </a>

--- a/templates/customer_portal/base_customer.html
+++ b/templates/customer_portal/base_customer.html
@@ -54,7 +54,11 @@
                         <img src="{{ request.tenant.logo.url }}" alt="{{ request.tenant.name }}" class="w-8 h-8 rounded-lg object-cover">
                         {% else %}
                         <div class="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
-                            <i class="fas fa-car-crash text-white text-sm"></i>
+                            <svg viewBox="0 0 40 40" class="w-5 h-5">
+                                <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                                <circle cx="32" cy="10" r="2" fill="white"/>
+                                <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                            </svg>
                         </div>
                         {% endif %}
                         <span class="text-lg font-bold text-gray-900 hidden sm:inline">
@@ -165,7 +169,11 @@
                     <img src="{{ request.tenant.logo.url }}" alt="{{ request.tenant.name }}" class="w-6 h-6 rounded object-cover">
                     {% else %}
                     <div class="w-6 h-6 bg-blue-600 rounded flex items-center justify-center">
-                        <i class="fas fa-car-crash text-white text-xs"></i>
+                        <svg viewBox="0 0 40 40" class="w-4 h-4">
+                            <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                            <circle cx="32" cy="10" r="2" fill="white"/>
+                            <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                        </svg>
                     </div>
                     {% endif %}
                     <span class="font-semibold text-gray-900">{% if request.tenant %}{{ request.tenant.name }}{% else %}RS Systems{% endif %}</span>

--- a/templates/saas/base_public.html
+++ b/templates/saas/base_public.html
@@ -45,7 +45,11 @@
             <div class="flex justify-between h-16 items-center">
                 <a href="/" class="flex items-center space-x-2">
                     <div class="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
-                        <i class="fas fa-car-crash text-white text-sm"></i>
+                        <svg viewBox="0 0 40 40" class="w-5 h-5">
+                            <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                            <circle cx="32" cy="10" r="2" fill="white"/>
+                            <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                        </svg>
                     </div>
                     <span class="text-xl font-bold text-gray-900">RS Systems</span>
                 </a>
@@ -96,7 +100,11 @@
             <div class="flex flex-col md:flex-row justify-between items-center">
                 <div class="flex items-center space-x-2 mb-4 md:mb-0">
                     <div class="w-6 h-6 bg-blue-600 rounded flex items-center justify-center">
-                        <i class="fas fa-car-crash text-white text-xs"></i>
+                        <svg viewBox="0 0 40 40" class="w-4 h-4">
+                            <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                            <circle cx="32" cy="10" r="2" fill="white"/>
+                            <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                        </svg>
                     </div>
                     <span class="font-semibold text-gray-900">RS Systems</span>
                 </div>

--- a/templates/saas/invite_accept.html
+++ b/templates/saas/invite_accept.html
@@ -21,7 +21,11 @@
         </div>
         <div class="max-w-md text-center relative z-10 px-8">
             <div class="w-20 h-20 bg-white/20 rounded-2xl flex items-center justify-center mx-auto mb-8">
-                <i class="fas fa-car-crash text-white text-3xl"></i>
+                <svg viewBox="0 0 40 40" class="w-12 h-12">
+                    <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                    <circle cx="32" cy="10" r="2" fill="white"/>
+                    <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                </svg>
             </div>
             <h1 class="text-4xl font-bold text-white mb-4">RS Systems</h1>
             <p class="text-xl text-blue-100 mb-8">You've been invited to join a team!</p>
@@ -54,7 +58,11 @@
             <!-- Mobile branding -->
             <div class="lg:hidden text-center mb-8">
                 <div class="w-14 h-14 bg-blue-600 rounded-xl flex items-center justify-center mx-auto mb-4">
-                    <i class="fas fa-car-crash text-white text-xl"></i>
+                    <svg viewBox="0 0 40 40" class="w-8 h-8">
+                        <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                        <circle cx="32" cy="10" r="2" fill="white"/>
+                        <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                    </svg>
                 </div>
                 <h1 class="text-3xl font-bold text-gray-900">RS Systems</h1>
             </div>

--- a/templates/saas/login.html
+++ b/templates/saas/login.html
@@ -13,7 +13,11 @@
         </div>
         <div class="max-w-md text-center relative z-10 px-8">
             <div class="w-20 h-20 bg-white/20 rounded-2xl flex items-center justify-center mx-auto mb-8">
-                <i class="fas fa-car-crash text-white text-3xl"></i>
+                <svg viewBox="0 0 40 40" class="w-12 h-12">
+                    <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                    <circle cx="32" cy="10" r="2" fill="white"/>
+                    <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                </svg>
             </div>
             <h1 class="text-4xl font-bold text-white mb-4">RS Systems</h1>
             <p class="text-xl text-blue-100 mb-8">The complete platform for windshield repair & replacement shops.</p>
@@ -52,7 +56,11 @@
             <!-- Mobile branding -->
             <div class="lg:hidden text-center mb-8">
                 <div class="w-14 h-14 bg-blue-600 rounded-xl flex items-center justify-center mx-auto mb-4">
-                    <i class="fas fa-car-crash text-white text-xl"></i>
+                    <svg viewBox="0 0 40 40" class="w-8 h-8">
+                        <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                        <circle cx="32" cy="10" r="2" fill="white"/>
+                        <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                    </svg>
                 </div>
                 <h1 class="text-3xl font-bold text-gray-900">RS Systems</h1>
                 <p class="text-gray-600 mt-1">Log in to your account</p>

--- a/templates/saas/pricing.html
+++ b/templates/saas/pricing.html
@@ -28,7 +28,11 @@
             <div class="flex items-center justify-between h-16">
                 <a href="/" class="flex items-center gap-2 font-bold text-lg text-gray-900">
                     <div class="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
-                        <i class="fas fa-car-crash text-white text-sm"></i>
+                        <svg viewBox="0 0 40 40" class="w-5 h-5">
+                            <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                            <circle cx="32" cy="10" r="2" fill="white"/>
+                            <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                        </svg>
                     </div>
                     RS Systems
                 </a>

--- a/templates/saas/signup.html
+++ b/templates/saas/signup.html
@@ -13,7 +13,11 @@
         </div>
         <div class="max-w-md text-center relative z-10 px-8">
             <div class="w-20 h-20 bg-white/20 rounded-2xl flex items-center justify-center mx-auto mb-8">
-                <i class="fas fa-car-crash text-white text-3xl"></i>
+                <svg viewBox="0 0 40 40" class="w-12 h-12">
+                    <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                    <circle cx="32" cy="10" r="2" fill="white"/>
+                    <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                </svg>
             </div>
             <h1 class="text-4xl font-bold text-white mb-4">RS Systems</h1>
             <p class="text-xl text-blue-100 mb-8">The complete platform for windshield repair & replacement shops.</p>
@@ -52,7 +56,11 @@
             <!-- Mobile branding -->
             <div class="lg:hidden text-center mb-8">
                 <div class="w-14 h-14 bg-blue-600 rounded-xl flex items-center justify-center mx-auto mb-4">
-                    <i class="fas fa-car-crash text-white text-xl"></i>
+                    <svg viewBox="0 0 40 40" class="w-8 h-8">
+                        <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800" font-family="Inter, sans-serif">RS</text>
+                        <circle cx="32" cy="10" r="2" fill="white"/>
+                        <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                    </svg>
                 </div>
                 <h1 class="text-3xl font-bold text-gray-900">RS Systems</h1>
                 <p class="text-gray-600 mt-1">Start your free 30-day trial</p>


### PR DESCRIPTION
## Overview
Applies the new RS + Sparkle logo (RS monogram with repair sparkle accent) consistently across all app templates.

## Updated Templates
- `saas/login.html` (desktop + mobile)
- `saas/signup.html` (desktop + mobile)
- `saas/invite_accept.html` (desktop + mobile)
- `saas/pricing.html`
- `saas/base_public.html` (nav + footer)
- `base_app.html` (main app nav)
- `customer_portal/base_customer.html` (nav + mobile)

## Not Changed
Kept `fa-car-crash` icon in repair forms and owner dashboard where it represents 'replacement' job type — it's a semantic icon there, not branding.

## The Logo
```svg
<svg viewBox="0 0 40 40">
    <text x="20" y="26" text-anchor="middle" fill="white" font-size="16" font-weight="800">RS</text>
    <circle cx="32" cy="10" r="2" fill="white"/>
    <path d="M32 5 L32 7 M32 13 L32 15 M27 10 L29 10 M35 10 L37 10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
</svg>
```