### PR TITLE
fix(UX-007): Show Add phone/email CTAs in customer detail when fields empty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Otherwise TaxService finds no rate and sets tax_rate=0.
 
 ## Branch Strategy
 
-- `main` — production (AWS Elastic Beanstalk, rockstarwindshield.repair)
+- `main` — production (AWS Elastic Beanstalk, rssystems.io)
 - `autonomous-work` — active development (Amelia's work branch)
 - PRs from `autonomous-work` → `main` for production deploys
 
@@ -217,7 +217,7 @@ Otherwise TaxService finds no rate and sets tax_rate=0.
 ```bash
 eb deploy        # from repo root on main branch
 eb events | head -20
-curl -I https://rockstarwindshield.repair/health/
+curl -I https://rssystems.io/health/
 ```
 
 **Deploy workflow:**
@@ -225,7 +225,7 @@ curl -I https://rockstarwindshield.repair/health/
 2. Merge into `main` via GitHub PR
 3. `git checkout main && git pull origin main`
 4. `eb deploy`
-5. Verify with `curl -I https://rockstarwindshield.repair/health/`
+5. Verify with `curl -I https://rssystems.io/health/`
 
 Required EB environment variable: `DJANGO_SETTINGS_MODULE=rs_systems.settings.production`
 
@@ -258,7 +258,7 @@ AWS_S3_REGION_NAME=us-east-1
 
 # SendGrid (email)
 SENDGRID_API_KEY=SG....
-DEFAULT_FROM_EMAIL=notifications@rockstarwindshield.repair
+DEFAULT_FROM_EMAIL=notifications@rssystems.io
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -334,7 +334,9 @@ Configure state/county/city tax rates at Settings → Billing → Tax Rates. Tax
 - **Frontend:** Tailwind CSS, Bootstrap, D3.js (data visualizations)
 - **Payments:** Stripe (subscriptions + invoice payments)
 - **Storage:** AWS S3 (photos, invoices)
-- **Email:** SendGrid (notifications, invitations, invoices)
+- **Email (outbound):** SendGrid (notifications, invitations, invoices) — sends from `notifications@rssystems.io`
+- **Email (inbound):** ImprovMX (forwards `contact@rssystems.io` to Gmail)
+- **DNS:** AWS Route 53
 - **Deployment:** AWS EC2 + Elastic Beanstalk
 
 ---
@@ -357,8 +359,9 @@ AWS_SECRET_ACCESS_KEY=...
 AWS_STORAGE_BUCKET_NAME=...
 AWS_S3_REGION_NAME=us-east-1
 
-# SendGrid (optional — for email delivery)
+# SendGrid (optional — for outbound email delivery)
 SENDGRID_API_KEY=SG....
+DEFAULT_FROM_EMAIL=notifications@rssystems.io
 ```
 
 ---
@@ -397,6 +400,20 @@ See the [`docs/`](docs/) directory for detailed guides:
 - [Developer Guide](docs/DEVELOPER_GUIDE.md)
 - [User Flows](docs/USER_FLOWS.md)
 - [API Docs](docs/user-guides/ADMIN_GUIDE.md) — or visit `/api/schema/swagger-ui/`
+
+---
+
+## Email Configuration
+
+### Outbound (SendGrid)
+- Sends from: `notifications@rssystems.io`
+- Domain authenticated via `em50.rssystems.io` CNAME records (DKIM + SPF)
+- Used for: repair notifications, invoice delivery, invitation emails, subscription alerts
+
+### Inbound (ImprovMX)
+- `contact@rssystems.io` forwards to the team inbox (Gmail)
+- MX records on Route 53: `mx1.improvmx.com` / `mx2.improvmx.com`
+- SPF record includes both `sendgrid.net` and `spf.improvmx.com`
 
 ---
 

--- a/apps/billing/admin.py
+++ b/apps/billing/admin.py
@@ -10,7 +10,10 @@ Provides admin interfaces for:
 Author: Amelia (Clawdbot AI)
 """
 
+import csv
+
 from django.contrib import admin
+from django.http import HttpResponse
 from django.utils.html import format_html
 from django.urls import reverse
 from decimal import Decimal
@@ -116,6 +119,8 @@ class InvoiceAdmin(admin.ModelAdmin):
     list_filter = ['status', 'invoice_date', 'due_date']
     search_fields = ['invoice_number', 'customer__name']
     date_hierarchy = 'invoice_date'
+    list_select_related = ['customer']
+    list_per_page = 25
     readonly_fields = [
         'invoice_number', 'created_at', 'updated_at', 'amount_paid', 
         'sent_at', 'paid_at'
@@ -192,8 +197,34 @@ class InvoiceAdmin(admin.ModelAdmin):
         return obj.line_items.count()
     line_item_count.short_description = 'Items'
     
-    actions = ['mark_as_sent', 'mark_as_overdue']
-    
+    actions = ['mark_as_sent', 'mark_as_overdue', 'export_csv']
+
+    @admin.action(description='📥 Export selected invoices as CSV')
+    def export_csv(self, request, queryset):
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="invoices.csv"'
+        writer = csv.writer(response)
+        writer.writerow([
+            'Invoice #', 'Customer', 'Invoice Date', 'Due Date',
+            'Payment Terms', 'Status', 'Subtotal', 'Tax', 'Total',
+            'Amount Paid', 'Amount Due',
+        ])
+        for inv in queryset.select_related('customer'):
+            writer.writerow([
+                inv.invoice_number,
+                inv.customer.name if inv.customer else '',
+                inv.invoice_date,
+                inv.due_date,
+                inv.payment_terms,
+                inv.status,
+                inv.subtotal,
+                inv.tax_amount,
+                inv.total,
+                inv.amount_paid,
+                inv.amount_due,
+            ])
+        return response
+
     @admin.action(description='Mark selected invoices as Sent')
     def mark_as_sent(self, request, queryset):
         updated = 0
@@ -222,6 +253,8 @@ class PaymentAdmin(admin.ModelAdmin):
     search_fields = ['invoice__invoice_number', 'reference_number', 'notes']
     date_hierarchy = 'payment_date'
     readonly_fields = ['created_at']
+    list_select_related = ['invoice']
+    list_per_page = 25
     
     def invoice_link(self, obj):
         url = reverse('admin:billing_invoice_change', args=[obj.invoice.id])

--- a/apps/billing/admin.py
+++ b/apps/billing/admin.py
@@ -19,6 +19,7 @@ from django.urls import reverse
 from decimal import Decimal
 
 from .models import BillingConfig, Invoice, InvoiceLineItem, Payment, TaxRate
+from rs_systems.admin_mixins import TenantFilterMixin
 
 
 # =============================================================================
@@ -107,19 +108,19 @@ class PaymentInline(admin.TabularInline):
 
 
 @admin.register(Invoice)
-class InvoiceAdmin(admin.ModelAdmin):
+class InvoiceAdmin(TenantFilterMixin, admin.ModelAdmin):
     """Admin for Invoice model."""
     
     list_display = [
-        'invoice_number', 'customer_link', 'invoice_date', 'due_date',
+        'invoice_number', 'get_tenant', 'customer_link', 'invoice_date', 'due_date',
         'payment_terms',
         'total_display', 'amount_paid_display', 'amount_due_display', 
         'status_badge', 'line_item_count'
     ]
-    list_filter = ['status', 'invoice_date', 'due_date']
+    list_filter = ['tenant', 'status', 'invoice_date', 'due_date']
     search_fields = ['invoice_number', 'customer__name']
     date_hierarchy = 'invoice_date'
-    list_select_related = ['customer']
+    list_select_related = ['customer', 'tenant']
     list_per_page = 25
     readonly_fields = [
         'invoice_number', 'created_at', 'updated_at', 'amount_paid', 
@@ -152,6 +153,11 @@ class InvoiceAdmin(admin.ModelAdmin):
     
     inlines = [InvoiceLineItemInline, PaymentInline]
     
+    def get_tenant(self, obj):
+        return obj.tenant.name if obj.tenant else '—'
+    get_tenant.short_description = 'Tenant'
+    get_tenant.admin_order_field = 'tenant__name'
+
     def customer_link(self, obj):
         url = reverse('admin:core_customer_change', args=[obj.customer.id])
         return format_html('<a href="{}">{}</a>', url, obj.customer.name)
@@ -242,19 +248,30 @@ class InvoiceAdmin(admin.ModelAdmin):
 
 
 @admin.register(Payment)
-class PaymentAdmin(admin.ModelAdmin):
+class PaymentAdmin(TenantFilterMixin, admin.ModelAdmin):
     """Admin for Payment model."""
-    
+
+    # Payments have no direct tenant FK; filter through invoice -> customer -> tenant
+    tenant_field = 'invoice__customer__tenant'
+
     list_display = [
-        'id', 'invoice_link', 'amount_display', 'payment_date', 
+        'id', 'get_tenant', 'invoice_link', 'amount_display', 'payment_date', 
         'payment_method', 'reference_number', 'created_at'
     ]
     list_filter = ['payment_method', 'payment_date']
     search_fields = ['invoice__invoice_number', 'reference_number', 'notes']
     date_hierarchy = 'payment_date'
     readonly_fields = ['created_at']
-    list_select_related = ['invoice']
+    list_select_related = ['invoice', 'invoice__customer', 'invoice__customer__tenant']
     list_per_page = 25
+
+    def get_tenant(self, obj):
+        try:
+            return obj.invoice.customer.tenant.name
+        except AttributeError:
+            return '—'
+    get_tenant.short_description = 'Tenant'
+    get_tenant.admin_order_field = 'invoice__customer__tenant__name'
     
     def invoice_link(self, obj):
         url = reverse('admin:billing_invoice_change', args=[obj.invoice.id])

--- a/apps/customer_portal/admin.py
+++ b/apps/customer_portal/admin.py
@@ -1,65 +1,62 @@
+import csv
+
 from django.contrib import admin
+from django.http import HttpResponse
 from django import forms
 from .models import CustomerUser, CustomerPreference, RepairApproval, CustomerRepairPreference, CustomerInvitation
 from .pricing_models import CustomerPricing
 
-# Custom admin class for CustomerUser model
+
+@admin.register(CustomerUser)
 class CustomerUserAdmin(admin.ModelAdmin):
-    # Define the fields to display in the list view
     list_display = ['user', 'customer', 'get_email', 'get_full_name', 'is_primary_contact']
-    # Define the fields to filter by in the list view
     list_filter = ['is_primary_contact', 'customer']
-    # Define the fields to search by in the list view
     search_fields = ['user__username', 'user__email', 'user__first_name', 'user__last_name', 'customer__name']
-    # Select related fields to improve performance
     list_select_related = ['user', 'customer']
-    
-    # Method to display the user's email in the list view
+    list_per_page = 25
+
     def get_email(self, obj):
         return obj.user.email
-    get_email.short_description = 'Email'  # Column header in the list view
-    get_email.admin_order_field = 'user__email'  # Field to order by
-    
-    # Method to display the user's full name in the list view
+    get_email.short_description = 'Email'
+    get_email.admin_order_field = 'user__email'
+
     def get_full_name(self, obj):
         return f"{obj.user.first_name} {obj.user.last_name}"
-    get_full_name.short_description = 'Full Name'  # Column header in the list view
-    get_full_name.admin_order_field = 'user__first_name'  # Field to order by
-    
-    # Define the layout of the form in the detail view
+    get_full_name.short_description = 'Full Name'
+    get_full_name.admin_order_field = 'user__first_name'
+
     fieldsets = (
         (None, {
             'fields': ('user', 'customer', 'is_primary_contact')
         }),
     )
 
-# Custom admin class for CustomerPreference model
+
+@admin.register(CustomerPreference)
 class CustomerPreferenceAdmin(admin.ModelAdmin):
-    # Define the fields to display in the list view
     list_display = ['customer', 'receive_email_notifications', 'receive_sms_notifications', 'default_view']
-    # Define the fields to filter by in the list view
     list_filter = ['receive_email_notifications', 'receive_sms_notifications', 'default_view']
-    # Define the fields to search by in the list view
     search_fields = ['customer__name']
+    list_per_page = 25
 
-# Custom admin class for RepairApproval model
+
+@admin.register(RepairApproval)
 class RepairApprovalAdmin(admin.ModelAdmin):
-    # Define the fields to display in the list view
     list_display = ['repair', 'approved', 'approved_by', 'approval_date']
-    # Define the fields to filter by in the list view
     list_filter = ['approved', 'approval_date']
-    # Define the fields to search by in the list view
     search_fields = ['repair__id', 'repair__customer__name', 'approved_by__user__username']
-    # Make the approval_date field read-only
     readonly_fields = ['approval_date']
+    list_per_page = 25
 
-# Custom admin class for CustomerPricing model
+
+@admin.register(CustomerPricing)
 class CustomerPricingAdmin(admin.ModelAdmin):
     list_display = ['customer', 'use_custom_pricing', 'created_at', 'created_by']
     list_filter = ['use_custom_pricing', 'created_at']
     search_fields = ['customer__name', 'notes']
     list_select_related = ['customer', 'created_by']
     readonly_fields = ['created_at', 'updated_at']
+    list_per_page = 25
 
     fieldsets = (
         ('Customer & Settings', {
@@ -85,25 +82,13 @@ class CustomerPricingAdmin(admin.ModelAdmin):
             obj.created_by = request.user
         super().save_model(request, obj, form, change)
 
+
 # Custom form for CustomerRepairPreference with conditional validation
 class CustomerRepairPreferenceForm(forms.ModelForm):
     """
     Enhanced form for CustomerRepairPreference model with lot walking configuration.
-
-    Features:
-    - Field repair approval mode selection (AUTO_APPROVE, REQUIRE_APPROVAL, UNIT_THRESHOLD)
-    - Unit threshold validation (required only when using UNIT_THRESHOLD mode)
-    - Lot walking service configuration with user-friendly widgets
-    - Automatic conversion between JSONField storage and checkbox UI
-
-    Lot Walking Fields:
-    - lot_walking_enabled: Boolean checkbox to enable/disable service
-    - lot_walking_frequency: Dropdown (Weekly/Bi-weekly/Monthly/Quarterly)
-    - lot_walking_time: Time picker for preferred time
-    - lot_walking_days_choices: Checkbox widget for selecting days (converts to/from JSON)
     """
 
-    # Days of week for lot walking (multi-select checkboxes)
     DAYS_OF_WEEK = [
         ('Monday', 'Monday'),
         ('Tuesday', 'Tuesday'),
@@ -114,8 +99,6 @@ class CustomerRepairPreferenceForm(forms.ModelForm):
         ('Sunday', 'Sunday'),
     ]
 
-    # Override the lot_walking_days JSONField to make it checkbox-friendly in admin
-    # This field is NOT in the model - it's a UI-only field that converts to/from JSON
     lot_walking_days_choices = forms.MultipleChoiceField(
         choices=DAYS_OF_WEEK,
         widget=forms.CheckboxSelectMultiple,
@@ -135,137 +118,50 @@ class CustomerRepairPreferenceForm(forms.ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
-        """
-        Custom initialization to pre-populate the days checkboxes from JSONField data.
-
-        When editing an existing CustomerRepairPreference, this converts the
-        lot_walking_days JSONField (e.g., ['Monday', 'Wednesday', 'Friday'])
-        into initial checkbox selections for the admin UI.
-
-        Args:
-            *args: Positional arguments passed to parent form
-            **kwargs: Keyword arguments including 'instance' for existing objects
-        """
         super().__init__(*args, **kwargs)
-
-        # If editing existing preference, populate the days checkboxes from JSON data
         if self.instance and self.instance.pk and self.instance.lot_walking_days:
             self.fields['lot_walking_days_choices'].initial = self.instance.lot_walking_days
 
     def clean(self):
-        """
-        Validate form data with conditional requirements for approval and lot walking settings.
-
-        Validation Rules:
-        1. Field Repair Approval:
-           - units_per_visit_threshold required when mode is UNIT_THRESHOLD
-           - units_per_visit_threshold cleared when mode is not UNIT_THRESHOLD
-
-        2. Lot Walking Service:
-           - lot_walking_frequency required when lot_walking_enabled is True
-           - lot_walking_time optional (preferred time for lot walks)
-           - lot_walking_days optional (defaults to empty list if not selected)
-
-        Returns:
-            dict: Cleaned and validated form data
-
-        Raises:
-            ValidationError: If required fields are missing based on mode selection
-        """
         cleaned_data = super().clean()
         approval_mode = cleaned_data.get('field_repair_approval_mode')
         threshold = cleaned_data.get('units_per_visit_threshold')
         lot_walking_enabled = cleaned_data.get('lot_walking_enabled')
         lot_walking_frequency = cleaned_data.get('lot_walking_frequency')
-        lot_walking_time = cleaned_data.get('lot_walking_time')
 
-        # Require threshold only when mode is UNIT_THRESHOLD
         if approval_mode == 'UNIT_THRESHOLD' and not threshold:
             raise forms.ValidationError({
                 'units_per_visit_threshold': 'This field is required when using Unit Threshold mode.'
             })
 
-        # Clear threshold when not using UNIT_THRESHOLD mode (prevents confusion)
         if approval_mode != 'UNIT_THRESHOLD' and threshold is not None:
             cleaned_data['units_per_visit_threshold'] = None
 
-        # Validate lot walking settings - only frequency required if service enabled
         if lot_walking_enabled:
             if not lot_walking_frequency:
                 raise forms.ValidationError({
                     'lot_walking_frequency': 'Frequency is required when lot walking is enabled.'
                 })
-            # Note: lot_walking_time and lot_walking_days are optional
 
         return cleaned_data
 
     def save(self, commit=True):
-        """
-        Custom save method to convert checkbox selections to JSONField storage.
-
-        This method bridges the gap between the checkbox UI (lot_walking_days_choices)
-        and the database JSONField (lot_walking_days). It converts selected days from
-        the checkbox widget into a JSON list for storage.
-
-        Example:
-            User selects: [Monday, Wednesday, Friday] (checkboxes)
-            Stored as: ['Monday', 'Wednesday', 'Friday'] (JSON)
-
-        Args:
-            commit (bool): Whether to save to database immediately (default: True)
-
-        Returns:
-            CustomerRepairPreference: The saved instance
-        """
         instance = super().save(commit=False)
-
-        # Convert checkbox selections to list and store in JSONField
-        # lot_walking_days_choices is UI-only, lot_walking_days is the actual model field
         instance.lot_walking_days = self.cleaned_data.get('lot_walking_days_choices', [])
-
         if commit:
             instance.save()
-
         return instance
 
-# Custom admin class for CustomerRepairPreference model
+
+@admin.register(CustomerRepairPreference)
 class CustomerRepairPreferenceAdmin(admin.ModelAdmin):
-    """
-    Django admin configuration for CustomerRepairPreference model.
-
-    Features:
-    - Field repair approval workflow configuration (AUTO_APPROVE, REQUIRE_APPROVAL, UNIT_THRESHOLD)
-    - Lot walking service scheduling preferences
-    - Enhanced list view showing approval mode and lot walking status
-    - Filtering by approval mode, lot walking enabled/frequency
-    - Organized fieldsets for better UX
-
-    List Display Columns:
-    - Customer name
-    - Approval mode (with display name)
-    - Unit threshold (if applicable)
-    - Lot walking enabled (✓/✗)
-    - Lot walking frequency (Weekly/Bi-weekly/Monthly/Quarterly)
-    - Last updated timestamp
-
-    Filtering Options:
-    - Field repair approval mode
-    - Lot walking enabled (Yes/No)
-    - Lot walking frequency
-    - Update date
-
-    Fieldsets:
-    1. Customer - Select which customer this preference applies to
-    2. Field Repair Approval Settings - Configure approval workflow
-    3. Lot Walking Service Settings - Configure lot walking schedule (NEW in v1.6.1)
-    4. Tracking - Created/updated timestamps (collapsed)
-    """
     form = CustomerRepairPreferenceForm
     list_display = ['customer', 'field_repair_approval_mode', 'units_per_visit_threshold', 'invoice_preference', 'auto_email_invoices', 'lot_walking_enabled', 'updated_at']
     list_filter = ['field_repair_approval_mode', 'invoice_preference', 'auto_email_invoices', 'lot_walking_enabled', 'lot_walking_frequency', 'updated_at']
     search_fields = ['customer__name']
     list_select_related = ['customer']
     readonly_fields = ['created_at', 'updated_at']
+    list_per_page = 25
 
     fieldsets = (
         ('Customer', {
@@ -277,14 +173,16 @@ class CustomerRepairPreferenceAdmin(admin.ModelAdmin):
         }),
         ('Lot Walking Service Settings', {
             'fields': ('lot_walking_enabled', 'lot_walking_frequency', 'lot_walking_time', 'lot_walking_days_choices'),
-            'description': 'Configure scheduled lot walking service for this customer. Enable the service and set the frequency, preferred time, and days.'
+            'description': 'Configure scheduled lot walking service for this customer.'
         }),
         ('Invoice Settings', {
             'fields': ('invoice_preference', 'billing_email', 'auto_email_invoices', 'include_photos_in_invoice'),
-            'description': 'Configure how invoices should be generated and delivered for this customer. '
-                          '"Per repair" = auto-generate when each repair completes. '
-                          '"Batch" = group repairs together (manual trigger). '
-                          '"Manual" = never auto-generate.'
+            'description': (
+                'Configure how invoices should be generated and delivered for this customer. '
+                '"Per repair" = auto-generate when each repair completes. '
+                '"Batch" = group repairs together (manual trigger). '
+                '"Manual" = never auto-generate.'
+            )
         }),
         ('Tracking', {
             'fields': ('created_at', 'updated_at'),
@@ -292,15 +190,19 @@ class CustomerRepairPreferenceAdmin(admin.ModelAdmin):
         }),
     )
 
-# CustomerInvitation Admin
+
+@admin.register(CustomerInvitation)
 class CustomerInvitationAdmin(admin.ModelAdmin):
     list_display = ['email', 'customer', 'status', 'created_at', 'expires_at', 'sent_at']
     list_filter = ['status', 'created_at']
     search_fields = ['email', 'customer__name', 'first_name', 'last_name']
     readonly_fields = ['token', 'created_at', 'sent_at', 'accepted_at', 'accepted_user']
-    raw_id_fields = ['customer', 'invited_by', 'accepted_user']
+    # customer and invited_by have search_fields on their target admins → use autocomplete
+    autocomplete_fields = ['customer', 'invited_by']
+    raw_id_fields = ['accepted_user']  # User is rarely searched by accepted_user context
     ordering = ['-created_at']
-    
+    list_per_page = 25
+
     fieldsets = (
         ('Invitation Details', {
             'fields': ('customer', 'email', 'first_name', 'last_name', 'status')
@@ -313,12 +215,3 @@ class CustomerInvitationAdmin(admin.ModelAdmin):
             'classes': ('collapse',)
         }),
     )
-
-
-# Register the models with their custom admin classes
-admin.site.register(CustomerUser, CustomerUserAdmin)
-admin.site.register(CustomerPreference, CustomerPreferenceAdmin)
-admin.site.register(RepairApproval, RepairApprovalAdmin)
-admin.site.register(CustomerPricing, CustomerPricingAdmin)
-admin.site.register(CustomerRepairPreference, CustomerRepairPreferenceAdmin)
-admin.site.register(CustomerInvitation, CustomerInvitationAdmin) 

--- a/apps/rewards_referrals/admin.py
+++ b/apps/rewards_referrals/admin.py
@@ -26,9 +26,12 @@ class RewardRedemptionAdmin(admin.ModelAdmin):
         'reward_option__name',
         'notes'
     ]
-    raw_id_fields = ['reward', 'reward_option', 'processed_by', 'assigned_technician', 'applied_to_repair']
+    # autocomplete_fields where target admins have search_fields defined
+    autocomplete_fields = ['reward_option', 'processed_by', 'assigned_technician', 'applied_to_repair']
+    raw_id_fields = ['reward']  # Reward admin has search_fields but reward__customer_user chain is complex
     date_hierarchy = 'created_at'
     readonly_fields = ['created_at', 'processed_at', 'fulfilled_at']
+    list_per_page = 25
     
     fieldsets = [
         ('Redemption Information', {
@@ -115,6 +118,7 @@ class RewardOptionAdmin(admin.ModelAdmin):
     list_editable = ['points_required', 'is_active']
     date_hierarchy = 'created_at'
     readonly_fields = ['created_at', 'updated_at']
+    list_per_page = 25
     
     fieldsets = [
         ('Basic Information', {
@@ -154,6 +158,7 @@ class RewardAdmin(admin.ModelAdmin):
     list_filter = ['created_at']
     readonly_fields = ['created_at', 'updated_at']
     date_hierarchy = 'created_at'
+    list_per_page = 25
     
     fieldsets = [
         ('Customer Information', {
@@ -194,6 +199,7 @@ class ReferralCodeAdmin(admin.ModelAdmin):
     list_filter = ['created_at']
     readonly_fields = ['created_at', 'updated_at']
     date_hierarchy = 'created_at'
+    list_per_page = 25
     
     fieldsets = [
         ('Referral Code', {
@@ -245,6 +251,7 @@ class ReferralAdmin(admin.ModelAdmin):
     list_filter = ['created_at']
     readonly_fields = ['created_at']
     date_hierarchy = 'created_at'
+    list_per_page = 25
     
     fieldsets = [
         ('Referral Details', {
@@ -296,6 +303,7 @@ class RewardTypeAdmin(admin.ModelAdmin):
     list_filter = ['category', 'discount_type', 'is_active']
     search_fields = ['name', 'description']
     list_editable = ['discount_value', 'is_active']
+    list_per_page = 25
     
     fieldsets = [
         ('Basic Information', {

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -300,11 +300,23 @@ def onboarding_view(request):
                                     from django.contrib.auth.models import Group
                                     tech_group, _ = Group.objects.get_or_create(name='Technicians')
                                     tech_user.groups.add(tech_group)
-                                    messages.success(request, 'Technician added!')
+                                    tech_display = f"{tech_first} {tech_last}".strip() or tech_email or 'Technician'
+                                    if tech_email:
+                                        messages.success(
+                                            request,
+                                            f'{tech_display} has been added to your team. '
+                                            f'Go to Settings → Team to send them an invite so they can log in.'
+                                        )
+                                    else:
+                                        messages.success(
+                                            request,
+                                            f'{tech_display} has been added to your team. '
+                                            f'Add their email in Settings → Team to send a login invite.'
+                                        )
                                 else:
                                     messages.info(request, 'A user with that email already exists.')
                             else:
-                                messages.info(request, 'No technician info provided.')
+                                messages.info(request, 'No technician info provided — you can add team members later in Settings → Team.')
 
                 except Exception as e:
                     logger.error(f"Onboarding tech error: {e}")

--- a/apps/technician_portal/admin.py
+++ b/apps/technician_portal/admin.py
@@ -1,46 +1,40 @@
+import csv
+
 from django.contrib import admin
 from django.contrib.admin.widgets import FilteredSelectMultiple
+from django.http import HttpResponse
 from django.urls import path
-from django.shortcuts import render, redirect
+from django.shortcuts import render
 from django.contrib.auth.models import User
 from django.utils.html import format_html
 from django import forms
 from .models import Technician, Repair, Replacement, UnitRepairCount, Customer, ViscosityRecommendation
 
+
+@admin.register(Technician)
 class TechnicianAdmin(admin.ModelAdmin):
     list_display = ['user', 'get_email', 'get_full_name', 'phone_number', 'expertise', 'is_manager', 'is_active', 'repairs_completed']
     list_filter = ['expertise', 'is_manager', 'is_active', 'can_assign_work', 'can_override_pricing']
     search_fields = ['user__username', 'user__email', 'user__first_name', 'user__last_name', 'phone_number']
     list_select_related = ['user']
     filter_horizontal = ['managed_technicians']
+    list_per_page = 25
 
     def get_form(self, request, obj=None, **kwargs):
-        """Customize form based on manager status"""
         form = super().get_form(request, obj, **kwargs)
-
-        # If editing an existing non-manager, hide managed_technicians field
         if obj and not obj.is_manager:
             if 'managed_technicians' in form.base_fields:
                 form.base_fields['managed_technicians'].widget = forms.HiddenInput()
-
-        # For managers, show only active technicians (exclude self)
         if 'managed_technicians' in form.base_fields:
             queryset = Technician.objects.filter(is_active=True).order_by('user__first_name')
             if obj:
-                # Exclude self from managed_technicians options
                 queryset = queryset.exclude(id=obj.id)
             form.base_fields['managed_technicians'].queryset = queryset
-            # Use FilteredSelectMultiple for better UX with many technicians
             form.base_fields['managed_technicians'].widget = FilteredSelectMultiple('Managed Technicians', False)
-
         return form
 
     def save_model(self, request, obj, form, change):
-        """Validate and save technician, clearing managed_technicians for non-managers"""
-        # Save first to ensure object has a pk for M2M access
         super().save_model(request, obj, form, change)
-
-        # Clear managed technicians for non-managers (must happen after save)
         if not obj.is_manager:
             obj.managed_technicians.clear()
 
@@ -73,26 +67,29 @@ class TechnicianAdmin(admin.ModelAdmin):
             'description': 'Working hours in JSON format: {"monday": ["9:00", "17:00"], ...}'
         }),
     )
-    
+
     def get_urls(self):
         urls = super().get_urls()
         custom_urls = [
             path('register-technician/', self.register_technician_view, name='register-technician'),
         ]
         return custom_urls + urls
-    
+
     def register_technician_view(self, request):
-        # This is a placeholder for your registration view
         return render(request, 'admin/register_technician.html', {})
 
+
+@admin.register(Repair)
 class RepairAdmin(admin.ModelAdmin):
     list_display = ['id', 'tenant', 'customer', 'unit_number', 'technician', 'get_status_badge', 'get_price_display', 'service_date']
     list_filter = ['tenant', 'queue_status', 'service_date', 'technician']
     search_fields = ['customer__name', 'unit_number', 'damage_type', 'technician__user__username', 'tenant__name']
     readonly_fields = ['service_date']
     date_hierarchy = 'service_date'
-    list_select_related = ['customer', 'technician', 'technician__user']
-    
+    list_select_related = ['customer', 'technician', 'technician__user', 'tenant']
+    list_per_page = 25
+    actions = ['export_csv']
+
     def get_status_badge(self, obj):
         status_colors = {
             'REQUESTED': 'bg-secondary',
@@ -117,7 +114,7 @@ class RepairAdmin(admin.ModelAdmin):
         return f"${obj.cost:.2f}"
     get_price_display.short_description = 'Price'
     get_price_display.admin_order_field = 'cost'
-    
+
     fieldsets = (
         ('Basic Information', {
             'fields': ('technician', 'customer', 'unit_number', 'service_date')
@@ -135,15 +132,40 @@ class RepairAdmin(admin.ModelAdmin):
         }),
     )
 
+    @admin.action(description='📥 Export selected repairs as CSV')
+    def export_csv(self, request, queryset):
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="repairs.csv"'
+        writer = csv.writer(response)
+        writer.writerow([
+            'ID', 'Tenant', 'Customer', 'Unit #', 'Technician',
+            'Status', 'Damage Type', 'Cost', 'Service Date',
+        ])
+        for repair in queryset.select_related('customer', 'technician__user', 'tenant'):
+            writer.writerow([
+                repair.id,
+                repair.tenant.name if repair.tenant else '',
+                repair.customer.name if repair.customer else '',
+                repair.unit_number,
+                repair.technician.user.get_full_name() if repair.technician else '',
+                repair.get_queue_status_display(),
+                repair.damage_type,
+                repair.cost,
+                repair.service_date,
+            ])
+        return response
 
+
+@admin.register(Replacement)
 class ReplacementAdmin(admin.ModelAdmin):
     list_display = ['id', 'tenant', 'customer', 'unit_number', 'glass_position', 'technician', 'get_status_badge', 'get_price_display', 'service_date']
     list_filter = ['tenant', 'queue_status', 'service_date', 'technician', 'glass_position', 'requires_adas_calibration']
     search_fields = ['customer__name', 'unit_number', 'nags_number', 'technician__user__username', 'tenant__name']
     readonly_fields = ['service_date']
     date_hierarchy = 'service_date'
-    list_select_related = ['customer', 'technician', 'technician__user']
-    
+    list_select_related = ['customer', 'technician', 'technician__user', 'tenant']
+    list_per_page = 25
+
     def get_status_badge(self, obj):
         status_colors = {
             'REQUESTED': 'bg-secondary',
@@ -168,7 +190,7 @@ class ReplacementAdmin(admin.ModelAdmin):
         return f"${obj.cost:.2f}"
     get_price_display.short_description = 'Price'
     get_price_display.admin_order_field = 'cost'
-    
+
     fieldsets = (
         ('Basic Information', {
             'fields': ('technician', 'customer', 'unit_number', 'service_date')
@@ -187,11 +209,15 @@ class ReplacementAdmin(admin.ModelAdmin):
     )
 
 
+@admin.register(Customer)
 class CustomerAdmin(admin.ModelAdmin):
     list_display = ['name', 'tenant', 'email', 'phone', 'address', 'tax_exempt', 'get_primary_contact']
     search_fields = ['name', 'email', 'phone', 'tenant__name']
     list_filter = ['tenant', 'customer_type', 'tax_exempt']
-    
+    list_select_related = ['tenant']
+    list_per_page = 25
+    actions = ['export_csv']
+
     def get_primary_contact(self, obj):
         from apps.customer_portal.models import CustomerUser
         try:
@@ -199,21 +225,49 @@ class CustomerAdmin(admin.ModelAdmin):
             if primary:
                 return f"{primary.user.get_full_name()} ({primary.user.email})"
             return "No primary contact"
-        except:
+        except Exception:
             return "Error retrieving contact"
     get_primary_contact.short_description = 'Primary Contact'
 
+    @admin.action(description='📥 Export selected customers as CSV')
+    def export_csv(self, request, queryset):
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="customers.csv"'
+        writer = csv.writer(response)
+        writer.writerow([
+            'ID', 'Name', 'Tenant', 'Email', 'Phone', 'Address',
+            'Customer Type', 'Tax Exempt',
+        ])
+        for customer in queryset.select_related('tenant'):
+            writer.writerow([
+                customer.id,
+                customer.name,
+                customer.tenant.name if customer.tenant else '',
+                customer.email,
+                customer.phone,
+                customer.address,
+                getattr(customer, 'customer_type', ''),
+                customer.tax_exempt,
+            ])
+        return response
+
+
+@admin.register(UnitRepairCount)
 class UnitRepairCountAdmin(admin.ModelAdmin):
     list_display = ['customer', 'unit_number', 'repair_count']
     list_filter = ['customer']
     search_fields = ['customer__name', 'unit_number']
+    list_per_page = 25
 
+
+@admin.register(ViscosityRecommendation)
 class ViscosityRecommendationAdmin(admin.ModelAdmin):
     list_display = ['name', 'get_temp_range_display', 'recommended_viscosity', 'get_badge_preview', 'display_order', 'is_active']
     list_filter = ['badge_color', 'is_active']
     search_fields = ['name', 'recommended_viscosity', 'suggestion_text']
     list_editable = ['display_order', 'is_active']
     ordering = ['display_order', 'id']
+    list_per_page = 25
 
     fieldsets = (
         ('Basic Information', {
@@ -222,7 +276,7 @@ class ViscosityRecommendationAdmin(admin.ModelAdmin):
         }),
         ('Temperature Range', {
             'fields': ('min_temperature', 'max_temperature'),
-            'description': 'Set the temperature range in °F. Leave blank for no limit (e.g., blank min = applies to all temps below max)'
+            'description': 'Set the temperature range in °F. Leave blank for no limit.'
         }),
         ('Recommendation', {
             'fields': ('recommended_viscosity', 'suggestion_text', 'badge_color'),
@@ -231,31 +285,20 @@ class ViscosityRecommendationAdmin(admin.ModelAdmin):
     )
 
     def get_temp_range_display(self, obj):
-        """Display temperature range in a readable format"""
         return obj._get_temp_range_display()
     get_temp_range_display.short_description = 'Temperature Range'
 
     def get_badge_preview(self, obj):
-        """Show a preview of the badge color"""
         color_map = {
-            'blue': '#1e40af',
-            'green': '#065f46',
-            'orange': '#9a3412',
-            'red': '#991b1b',
-            'yellow': '#92400e',
-            'purple': '#6b21a8',
+            'blue': '#1e40af', 'green': '#065f46', 'orange': '#9a3412',
+            'red': '#991b1b', 'yellow': '#92400e', 'purple': '#6b21a8',
         }
         bg_color_map = {
-            'blue': '#dbeafe',
-            'green': '#d1fae5',
-            'orange': '#fed7aa',
-            'red': '#fee2e2',
-            'yellow': '#fef3c7',
-            'purple': '#e9d5ff',
+            'blue': '#dbeafe', 'green': '#d1fae5', 'orange': '#fed7aa',
+            'red': '#fee2e2', 'yellow': '#fef3c7', 'purple': '#e9d5ff',
         }
         color = color_map.get(obj.badge_color, '#4b5563')
         bg = bg_color_map.get(obj.badge_color, '#f3f4f6')
-
         return format_html(
             '<span style="display: inline-block; padding: 4px 12px; background-color: {}; color: {}; border-radius: 4px; font-size: 12px; font-weight: 500;">{}</span>',
             bg, color, obj.recommended_viscosity
@@ -263,15 +306,6 @@ class ViscosityRecommendationAdmin(admin.ModelAdmin):
     get_badge_preview.short_description = 'Badge Preview'
 
     def save_model(self, request, obj, form, change):
-        """Add helpful validation messages"""
         super().save_model(request, obj, form, change)
-        if not change:  # New object
+        if not change:
             self.message_user(request, f'Created viscosity rule: {obj.name}', level='success')
-
-# Register the models
-admin.site.register(Technician, TechnicianAdmin)
-admin.site.register(Repair, RepairAdmin)
-admin.site.register(Replacement, ReplacementAdmin)
-admin.site.register(UnitRepairCount, UnitRepairCountAdmin)
-admin.site.register(Customer, CustomerAdmin)
-admin.site.register(ViscosityRecommendation, ViscosityRecommendationAdmin)

--- a/apps/technician_portal/admin.py
+++ b/apps/technician_portal/admin.py
@@ -9,10 +9,11 @@ from django.contrib.auth.models import User
 from django.utils.html import format_html
 from django import forms
 from .models import Technician, Repair, Replacement, UnitRepairCount, Customer, ViscosityRecommendation
+from rs_systems.admin_mixins import TenantFilterMixin
 
 
 @admin.register(Technician)
-class TechnicianAdmin(admin.ModelAdmin):
+class TechnicianAdmin(TenantFilterMixin, admin.ModelAdmin):
     list_display = ['user', 'get_email', 'get_full_name', 'phone_number', 'expertise', 'is_manager', 'is_active', 'repairs_completed']
     list_filter = ['expertise', 'is_manager', 'is_active', 'can_assign_work', 'can_override_pricing']
     search_fields = ['user__username', 'user__email', 'user__first_name', 'user__last_name', 'phone_number']
@@ -80,7 +81,7 @@ class TechnicianAdmin(admin.ModelAdmin):
 
 
 @admin.register(Repair)
-class RepairAdmin(admin.ModelAdmin):
+class RepairAdmin(TenantFilterMixin, admin.ModelAdmin):
     list_display = ['id', 'tenant', 'customer', 'unit_number', 'technician', 'get_status_badge', 'get_price_display', 'service_date']
     list_filter = ['tenant', 'queue_status', 'service_date', 'technician']
     search_fields = ['customer__name', 'unit_number', 'damage_type', 'technician__user__username', 'tenant__name']
@@ -157,7 +158,7 @@ class RepairAdmin(admin.ModelAdmin):
 
 
 @admin.register(Replacement)
-class ReplacementAdmin(admin.ModelAdmin):
+class ReplacementAdmin(TenantFilterMixin, admin.ModelAdmin):
     list_display = ['id', 'tenant', 'customer', 'unit_number', 'glass_position', 'technician', 'get_status_badge', 'get_price_display', 'service_date']
     list_filter = ['tenant', 'queue_status', 'service_date', 'technician', 'glass_position', 'requires_adas_calibration']
     search_fields = ['customer__name', 'unit_number', 'nags_number', 'technician__user__username', 'tenant__name']
@@ -210,13 +211,13 @@ class ReplacementAdmin(admin.ModelAdmin):
 
 
 @admin.register(Customer)
-class CustomerAdmin(admin.ModelAdmin):
+class CustomerAdmin(TenantFilterMixin, admin.ModelAdmin):
     list_display = ['name', 'tenant', 'email', 'phone', 'address', 'tax_exempt', 'get_primary_contact']
     search_fields = ['name', 'email', 'phone', 'tenant__name']
     list_filter = ['tenant', 'customer_type', 'tax_exempt']
     list_select_related = ['tenant']
     list_per_page = 25
-    actions = ['export_csv']
+    actions = ['export_csv', 'generate_invoices']
 
     def get_primary_contact(self, obj):
         from apps.customer_portal.models import CustomerUser
@@ -250,6 +251,87 @@ class CustomerAdmin(admin.ModelAdmin):
                 customer.tax_exempt,
             ])
         return response
+
+    @admin.action(description='🧾 Generate draft invoices for selected customers')
+    def generate_invoices(self, request, queryset):
+        """
+        For each selected customer, find completed repairs not yet on any invoice
+        and create a single DRAFT invoice containing all of them.
+        """
+        from django.utils import timezone
+        from apps.billing.models import Invoice, InvoiceLineItem, BillingConfig
+        from apps.technician_portal.models import Repair
+
+        invoices_created = 0
+        repairs_billed = 0
+        skipped = 0
+
+        config = BillingConfig.get_instance() if BillingConfig.objects.exists() else None
+        prefix = (config.invoice_number_prefix if config else None) or 'INV'
+
+        for customer in queryset.select_related('tenant'):
+            # Find completed repairs not yet linked to any invoice line item
+            unbilled_repairs = (
+                Repair.objects
+                .filter(customer=customer, queue_status='COMPLETED')
+                .exclude(invoice_line_items__isnull=False)
+                .order_by('service_date')
+            )
+
+            if not unbilled_repairs.exists():
+                skipped += 1
+                continue
+
+            # Generate a unique invoice number
+            timestamp = timezone.now().strftime('%Y%m%d%H%M%S')
+            invoice_number = f"{prefix}-{customer.id}-{timestamp}"
+
+            total = sum(r.cost for r in unbilled_repairs)
+
+            invoice = Invoice.objects.create(
+                tenant=customer.tenant,
+                customer=customer,
+                invoice_number=invoice_number,
+                status='DRAFT',
+                invoice_date=timezone.now().date(),
+                subtotal=total,
+                discount=0,
+                tax_rate=0,
+                tax_amount=0,
+                total=total,
+                amount_paid=0,
+                payment_terms=(config.default_payment_terms if config else 'NET30'),
+            )
+
+            for repair in unbilled_repairs:
+                InvoiceLineItem.objects.create(
+                    invoice=invoice,
+                    repair=repair,
+                    description=f"Windshield repair — Unit #{repair.unit_number}" if repair.unit_number else "Windshield repair",
+                    quantity=1,
+                    unit_price=repair.cost,
+                    discount=0,
+                    amount=repair.cost,
+                    repair_date=repair.service_date,
+                    unit_number=repair.unit_number or '',
+                )
+                repairs_billed += 1
+
+            invoices_created += 1
+
+        if invoices_created:
+            self.message_user(
+                request,
+                f"✅ Created {invoices_created} draft invoice(s) covering {repairs_billed} repair(s). "
+                f"{skipped} customer(s) had no unbilled completed repairs.",
+                level='success',
+            )
+        else:
+            self.message_user(
+                request,
+                f"No new invoices created — {skipped} customer(s) had no unbilled completed repairs.",
+                level='warning',
+            )
 
 
 @admin.register(UnitRepairCount)

--- a/apps/technician_portal/views/settings.py
+++ b/apps/technician_portal/views/settings.py
@@ -39,7 +39,6 @@ def get_ordinal_suffix(n):
         return {1: 'st', 2: 'nd', 3: 'rd'}.get(n % 10, 'th')
 
 
-@technician_required
 @manager_required
 def manager_settings_dashboard(request):
     """Main manager settings dashboard with navigation tiles."""
@@ -68,12 +67,14 @@ def manager_settings_dashboard(request):
     return render(request, 'technician_portal/settings/settings_dashboard.html', context)
 
 
-@technician_required
 @manager_required
 @ensure_csrf_cookie
 def manage_viscosity_rules(request):
     """Manage viscosity recommendation rules with card-based interface."""
-    manager = request.user.technician if hasattr(request.user, 'technician') else None
+    try:
+        manager = request.user.technician if hasattr(request.user, 'technician') else None
+    except Exception:
+        manager = None
 
     tenant = getattr(request, 'tenant', None)
     rules = ViscosityRecommendation.objects.all()
@@ -102,7 +103,6 @@ def manage_viscosity_rules(request):
     return render(request, 'technician_portal/settings/viscosity_rules.html', context)
 
 
-@technician_required
 @manager_required
 def get_viscosity_rule(request, rule_id):
     """AJAX endpoint to fetch a single viscosity recommendation rule."""
@@ -132,7 +132,6 @@ def get_viscosity_rule(request, rule_id):
         return JsonResponse({'success': False, 'error': str(e)}, status=500)
 
 
-@technician_required
 @manager_required
 def create_viscosity_rule(request):
     """AJAX endpoint to create a new viscosity recommendation rule."""
@@ -196,7 +195,6 @@ def create_viscosity_rule(request):
         return JsonResponse({'success': False, 'error': str(e)}, status=500)
 
 
-@technician_required
 @manager_required
 def update_viscosity_rule(request, rule_id):
     """AJAX endpoint to update an existing viscosity recommendation rule."""
@@ -248,7 +246,6 @@ def update_viscosity_rule(request, rule_id):
         return JsonResponse({'success': False, 'error': str(e)}, status=500)
 
 
-@technician_required
 @manager_required
 def delete_viscosity_rule(request, rule_id):
     """AJAX endpoint to delete a viscosity recommendation rule."""
@@ -270,7 +267,6 @@ def delete_viscosity_rule(request, rule_id):
         return JsonResponse({'success': False, 'error': str(e)}, status=500)
 
 
-@technician_required
 @manager_required
 def toggle_viscosity_rule(request, rule_id):
     """AJAX endpoint to toggle active status of a viscosity recommendation rule."""
@@ -293,7 +289,6 @@ def toggle_viscosity_rule(request, rule_id):
         return JsonResponse({'success': False, 'error': str(e)}, status=500)
 
 
-@technician_required
 @manager_required
 def team_overview(request):
     """Team overview dashboard showing managed technicians and their stats."""

--- a/apps/tenants/admin.py
+++ b/apps/tenants/admin.py
@@ -1,25 +1,39 @@
 from django.contrib import admin
+from django.utils import timezone
+from django.utils.html import format_html
 from .models import Tenant, TenantMembership, SubscriptionPlan
 
 
 class TenantMembershipInline(admin.TabularInline):
     model = TenantMembership
     extra = 1
-    raw_id_fields = ['user']
+    autocomplete_fields = ['user']
 
 
 @admin.register(Tenant)
 class TenantAdmin(admin.ModelAdmin):
     list_display = [
         'name', 'slug', 'owner', 'plan', 'subscription_plan',
-        'subscription_status', 'is_active', 'created_at',
+        'subscription_status', 'grace_period_end', 'had_paid_subscription_display',
+        'is_active', 'created_at',
     ]
     list_filter = ['is_active', 'plan', 'subscription_status']
     search_fields = ['name', 'slug', 'subdomain']
     prepopulated_fields = {'slug': ('name',)}
-    raw_id_fields = ['owner']
+    autocomplete_fields = ['owner']
     inlines = [TenantMembershipInline]
-    readonly_fields = ['created_at', 'updated_at', 'trial_started_at']
+    list_per_page = 25
+    readonly_fields = [
+        'created_at', 'updated_at', 'trial_started_at',
+        'grace_period_end', 'had_paid_subscription_display',
+        'is_in_grace_period_display', 'grace_days_remaining_display',
+    ]
+    actions = [
+        'extend_trial_7_days',
+        'extend_trial_30_days',
+        'activate_subscription',
+        'deactivate_subscription',
+    ]
     fieldsets = (
         (None, {
             'fields': ('name', 'slug', 'subdomain', 'owner'),
@@ -31,13 +45,92 @@ class TenantAdmin(admin.ModelAdmin):
             'fields': (
                 'plan', 'subscription_plan', 'subscription_status',
                 'trial_started_at',
+                'grace_period_end',
                 'stripe_customer_id', 'stripe_subscription_id',
+                'had_paid_subscription_display',
+                'is_in_grace_period_display',
+                'grace_days_remaining_display',
             ),
+        }),
+        ('Alerts', {
+            'fields': ('subscription_alerts_sent',),
+            'classes': ('collapse',),
+            'description': 'Tracks which subscription alert emails have been sent.',
         }),
         ('Status', {
             'fields': ('is_active', 'created_at', 'updated_at'),
         }),
     )
+
+    # -------------------------------------------------------------------------
+    # Computed display fields
+    # -------------------------------------------------------------------------
+
+    def had_paid_subscription_display(self, obj):
+        if obj.had_paid_subscription:
+            return format_html('<span style="color: green;">✓ Yes</span>')
+        return format_html('<span style="color: #999;">No</span>')
+    had_paid_subscription_display.short_description = 'Had Paid Sub?'
+    had_paid_subscription_display.boolean = False
+
+    def is_in_grace_period_display(self, obj):
+        if obj.is_in_grace_period:
+            days = obj.grace_days_remaining
+            return format_html(
+                '<span style="color: orange;">⏳ Yes ({} days left)</span>', days
+            )
+        return format_html('<span style="color: #999;">No</span>')
+    is_in_grace_period_display.short_description = 'In Grace Period?'
+
+    def grace_days_remaining_display(self, obj):
+        days = obj.grace_days_remaining
+        if days > 0:
+            return format_html('<strong>{}</strong> days', days)
+        return '—'
+    grace_days_remaining_display.short_description = 'Grace Days Remaining'
+
+    # -------------------------------------------------------------------------
+    # Admin actions — Subscription management (Phase 3)
+    # -------------------------------------------------------------------------
+
+    @admin.action(description='⏱ Extend trial by 7 days')
+    def extend_trial_7_days(self, request, queryset):
+        updated = 0
+        for tenant in queryset.filter(plan='trial'):
+            if not tenant.trial_started_at:
+                tenant.trial_started_at = timezone.now()
+            # Extend by shifting trial_started_at forward 7 days
+            tenant.trial_started_at = tenant.trial_started_at + timezone.timedelta(days=7)
+            tenant.save(update_fields=['trial_started_at'])
+            updated += 1
+        self.message_user(request, f'{updated} trial(s) extended by 7 days.')
+
+    @admin.action(description='⏱ Extend trial by 30 days')
+    def extend_trial_30_days(self, request, queryset):
+        updated = 0
+        for tenant in queryset.filter(plan='trial'):
+            if not tenant.trial_started_at:
+                tenant.trial_started_at = timezone.now()
+            tenant.trial_started_at = tenant.trial_started_at + timezone.timedelta(days=30)
+            tenant.save(update_fields=['trial_started_at'])
+            updated += 1
+        self.message_user(request, f'{updated} trial(s) extended by 30 days.')
+
+    @admin.action(description='✅ Activate subscription')
+    def activate_subscription(self, request, queryset):
+        updated = queryset.update(subscription_status='active', is_active=True)
+        self.message_user(request, f'{updated} tenant(s) activated.')
+
+    @admin.action(description='🚫 Deactivate subscription (set expired + 30-day grace)')
+    def deactivate_subscription(self, request, queryset):
+        grace_end = timezone.now() + timezone.timedelta(days=30)
+        updated = 0
+        for tenant in queryset:
+            tenant.subscription_status = 'expired'
+            tenant.grace_period_end = grace_end
+            tenant.save(update_fields=['subscription_status', 'grace_period_end'])
+            updated += 1
+        self.message_user(request, f'{updated} tenant(s) deactivated with 30-day grace period.')
 
 
 @admin.register(TenantMembership)
@@ -45,7 +138,9 @@ class TenantMembershipAdmin(admin.ModelAdmin):
     list_display = ['user', 'tenant', 'role', 'is_active', 'joined_at']
     list_filter = ['role', 'is_active']
     search_fields = ['user__username', 'user__email', 'tenant__name']
-    raw_id_fields = ['user', 'tenant']
+    autocomplete_fields = ['user', 'tenant']
+    list_select_related = ['user', 'tenant']
+    list_per_page = 25
 
 
 @admin.register(SubscriptionPlan)
@@ -58,6 +153,7 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
     list_filter = ['is_active']
     prepopulated_fields = {'slug': ('name',)}
     list_editable = ['display_order', 'is_active']
+    list_per_page = 25
     fieldsets = (
         (None, {
             'fields': ('name', 'slug', 'is_active', 'display_order'),

--- a/apps/tenants/management/commands/check_subscription_alerts.py
+++ b/apps/tenants/management/commands/check_subscription_alerts.py
@@ -279,7 +279,7 @@ class Command(BaseCommand):
                         f"Upgrade your subscription to regain access:\n"
                         f"https://rssystems.io/owner/billing/\n\n"
                         f"If you need help recovering your data, contact us at "
-                        f"support@rssystems.io\n\n"
+                        f"contact@rssystems.io\n\n"
                         f"— RS Systems"
                     ),
                     dry_run=dry_run,

--- a/apps/tenants/management/commands/check_subscription_alerts.py
+++ b/apps/tenants/management/commands/check_subscription_alerts.py
@@ -75,7 +75,7 @@ def _send_alert(tenant, alert_key, subject, body, dry_run=False):
         )
         return True
 
-    from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'notifications@rockstarwindshield.repair')
+    from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'notifications@rssystems.io')
     try:
         send_mail(
             subject=subject,
@@ -155,7 +155,7 @@ class Command(BaseCommand):
                         f"Your free trial for {tenant.name} ends in 7 days "
                         f"({tenant.trial_expiry.strftime('%B %d, %Y')}).\n\n"
                         f"Upgrade now to keep your data and avoid any service interruption:\n"
-                        f"https://rockstarwindshield.repair/owner/billing/\n\n"
+                        f"https://rssystems.io/owner/billing/\n\n"
                         f"— RS Systems"
                     ),
                     dry_run=dry_run,
@@ -171,7 +171,7 @@ class Command(BaseCommand):
                         f"Your free trial for {tenant.name} expires tomorrow "
                         f"({tenant.trial_expiry.strftime('%B %d, %Y')}).\n\n"
                         f"Don't lose access to your shop data! Upgrade today:\n"
-                        f"https://rockstarwindshield.repair/owner/billing/\n\n"
+                        f"https://rssystems.io/owner/billing/\n\n"
                         f"— RS Systems"
                     ),
                     dry_run=dry_run,
@@ -189,7 +189,7 @@ class Command(BaseCommand):
                     f"Your free trial for {tenant.name} has expired.\n\n"
                     f"You have 30 days of read-only access to your data before your account "
                     f"is fully locked. Upgrade now to restore full access:\n"
-                    f"https://rockstarwindshield.repair/owner/billing/\n\n"
+                    f"https://rssystems.io/owner/billing/\n\n"
                     f"— RS Systems"
                 )
             else:
@@ -200,7 +200,7 @@ class Command(BaseCommand):
                     f"Your subscription for {tenant.name} has ended.\n\n"
                     f"You have 30 days of read-only access to your data. "
                     f"Reactivate now to restore full access:\n"
-                    f"https://rockstarwindshield.repair/owner/billing/\n\n"
+                    f"https://rssystems.io/owner/billing/\n\n"
                     f"— RS Systems"
                 )
             if _send_alert(tenant, alert_key, subject=subject, body=body, dry_run=dry_run):
@@ -216,7 +216,7 @@ class Command(BaseCommand):
                     f"Your RS Systems subscription for {tenant.name} has expired.\n\n"
                     f"You have 30 days of read-only access to your data. "
                     f"Reactivate now to restore full access:\n"
-                    f"https://rockstarwindshield.repair/owner/billing/\n\n"
+                    f"https://rssystems.io/owner/billing/\n\n"
                     f"— RS Systems"
                 ),
                 dry_run=dry_run,
@@ -238,7 +238,7 @@ class Command(BaseCommand):
                         f"After {grace_end.strftime('%B %d, %Y')}, your account will be fully "
                         f"locked and you'll need to contact support to recover your data.\n\n"
                         f"Reactivate your subscription now:\n"
-                        f"https://rockstarwindshield.repair/owner/billing/\n\n"
+                        f"https://rssystems.io/owner/billing/\n\n"
                         f"— RS Systems"
                     ),
                     dry_run=dry_run,
@@ -255,7 +255,7 @@ class Command(BaseCommand):
                         f"day{'s' if days_remaining != 1 else ''}.\n\n"
                         f"After {grace_end.strftime('%B %d, %Y')}, you will lose access to "
                         f"your shop's data entirely. Upgrade now to avoid this:\n"
-                        f"https://rockstarwindshield.repair/owner/billing/\n\n"
+                        f"https://rssystems.io/owner/billing/\n\n"
                         f"— RS Systems"
                     ),
                     dry_run=dry_run,
@@ -277,9 +277,9 @@ class Command(BaseCommand):
                         f"Your read-only access period for {tenant.name} has ended.\n\n"
                         f"You no longer have access to your shop's data in RS Systems. "
                         f"Upgrade your subscription to regain access:\n"
-                        f"https://rockstarwindshield.repair/owner/billing/\n\n"
+                        f"https://rssystems.io/owner/billing/\n\n"
                         f"If you need help recovering your data, contact us at "
-                        f"support@rockstarwindshield.repair\n\n"
+                        f"support@rssystems.io\n\n"
                         f"— RS Systems"
                     ),
                     dry_run=dry_run,

--- a/core/admin.py
+++ b/core/admin.py
@@ -53,6 +53,7 @@ class NotificationAdmin(admin.ModelAdmin):
     ]
 
     actions = ['mark_as_read', 'mark_as_unread', 'retry_delivery']
+    list_per_page = 25
 
     def title_truncated(self, obj):
         return obj.title[:50] + '...' if len(obj.title) > 50 else obj.title

--- a/docs/archive/MANUAL_TEST_PLAN.md
+++ b/docs/archive/MANUAL_TEST_PLAN.md
@@ -25,7 +25,7 @@
 |---|------|----------|
 | 1.1 | Go to login page, click "Forgot Password" | Reset form loads |
 | 1.2 | Enter valid email, submit | "Email sent" confirmation |
-| 1.3 | Check email for reset link | Email arrives from notifications@rockstarwindshield.repair |
+| 1.3 | Check email for reset link | Email arrives from notifications@rssystems.io |
 | 1.4 | Click link, enter new password | Password changed, redirect to login |
 | 1.5 | Login with new password | Success |
 | 1.6 | Enter non-existent email | Should NOT reveal that email doesn't exist (security) |
@@ -95,11 +95,11 @@
 
 ---
 
-## 7. Domain & Branding Update (rockstarwindshield.repair → rssystems.io)
+## 7. Domain & Branding Update (rssystems.io → rssystems.io)
 
 | # | Step | Expected |
 |---|------|----------|
-| 7.1 | Search all visible pages for old domain references | No "rockstarwindshield.repair" in UI text |
+| 7.1 | Search all visible pages for old domain references | No "rssystems.io" in UI text |
 | 7.2 | Check email templates/subjects | New domain in links |
 | 7.3 | Check login page branding | Says "RS Systems" |
 | 7.4 | Check technician login page | Updated branding |

--- a/docs/development/SUBSCRIPTION_LIFECYCLE.md
+++ b/docs/development/SUBSCRIPTION_LIFECYCLE.md
@@ -79,7 +79,7 @@ When a trial expires or subscription is canceled:
 ### Implementation Plan
 1. **Celery beat task**: `check_trial_expirations` — runs daily at 9 AM UTC
 2. Query all tenants where `plan='trial'` and `trial_started_at` matches alert windows
-3. Use existing SendGrid integration via `notifications@rockstarwindshield.repair`
+3. Use existing SendGrid integration via `notifications@rssystems.io`
 4. Track sent alerts in a `TrialAlert` model (prevent duplicate sends):
    ```python
    class TrialAlert(models.Model):

--- a/rs_systems/admin.py
+++ b/rs_systems/admin.py
@@ -1,9 +1,12 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import User
+from django.contrib.admin.models import LogEntry, ADDITION, CHANGE, DELETION
 from django.urls import path
 from django.shortcuts import render, redirect
 from django.contrib import messages
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from apps.customer_portal.models import CustomerUser
 from apps.technician_portal.models import Technician
 from core.models import Customer
@@ -231,3 +234,132 @@ def _dashboard_index(self, request, extra_context=None):
 
 
 admin.AdminSite.index = _dashboard_index
+
+
+# =============================================================================
+# Phase 6b: Audit Log — nice view over Django's built-in LogEntry
+# =============================================================================
+
+@admin.register(LogEntry)
+class AuditLogAdmin(admin.ModelAdmin):
+    """
+    Read-only admin view over Django's built-in action log.
+    Shows who changed what and when, across all admin-managed models.
+    """
+
+    list_display = [
+        'action_time', 'user_link', 'action_badge', 'content_type',
+        'object_repr_short', 'change_message_short',
+    ]
+    list_filter = ['action_flag', 'content_type', 'action_time']
+    search_fields = ['user__username', 'user__email', 'object_repr', 'change_message']
+    date_hierarchy = 'action_time'
+    list_select_related = ['user', 'content_type']
+    list_per_page = 50
+    ordering = ['-action_time']
+
+    # No adding, editing, or deleting audit records
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def user_link(self, obj):
+        url = f"/admin/auth/user/{obj.user_id}/change/"
+        return format_html('<a href="{}">{}</a>', url, obj.user.get_full_name() or obj.user.username)
+    user_link.short_description = 'User'
+    user_link.admin_order_field = 'user__username'
+
+    def action_badge(self, obj):
+        flag_map = {
+            ADDITION: ('Added', '#28a745'),
+            CHANGE: ('Changed', '#007bff'),
+            DELETION: ('Deleted', '#dc3545'),
+        }
+        label, color = flag_map.get(obj.action_flag, ('Unknown', '#6c757d'))
+        return format_html(
+            '<span style="background: {}; color: white; padding: 2px 8px; '
+            'border-radius: 4px; font-size: 11px;">{}</span>',
+            color, label,
+        )
+    action_badge.short_description = 'Action'
+    action_badge.admin_order_field = 'action_flag'
+
+    def object_repr_short(self, obj):
+        return obj.object_repr[:60] + ('…' if len(obj.object_repr) > 60 else '')
+    object_repr_short.short_description = 'Object'
+
+    def change_message_short(self, obj):
+        msg = obj.get_change_message()
+        return msg[:100] + ('…' if len(msg) > 100 else '') if msg else '—'
+    change_message_short.short_description = 'Changes'
+
+
+# =============================================================================
+# Phase 6c: Global Admin Search
+# =============================================================================
+
+def _global_search_view(request):
+    """
+    Search across Customers, Repairs, Invoices, and Users in one shot.
+    Results are grouped by model type.
+    Accessible at /admin/search/
+    """
+    query = request.GET.get('q', '').strip()
+    results = {}
+
+    if query:
+        from apps.billing.models import Invoice
+        from apps.technician_portal.models import Repair
+        from django.db.models import Q
+
+        customers = Customer.objects.filter(
+            Q(name__icontains=query) | Q(email__icontains=query)
+        ).select_related('tenant')[:20]
+
+        repairs = Repair.objects.filter(
+            Q(unit_number__icontains=query) | Q(customer__name__icontains=query)
+        ).select_related('customer', 'tenant')[:20]
+
+        invoices = Invoice.objects.filter(
+            Q(invoice_number__icontains=query) | Q(customer__name__icontains=query)
+        ).select_related('customer', 'tenant')[:20]
+
+        users = User.objects.filter(
+            Q(username__icontains=query) | Q(email__icontains=query) |
+            Q(first_name__icontains=query) | Q(last_name__icontains=query)
+        )[:20]
+
+        results = {
+            'customers': customers,
+            'repairs': repairs,
+            'invoices': invoices,
+            'users': users,
+        }
+
+    context = {
+        **admin.site.each_context(request),
+        'title': 'Global Search',
+        'query': query,
+        'results': results,
+    }
+    return render(request, 'admin/global_search.html', context)
+
+
+# Monkey-patch get_urls to add our search URL
+_original_get_urls = admin.AdminSite.get_urls
+
+
+def _custom_get_urls(self):
+    original_urls = _original_get_urls(self)
+    custom = [
+        path('search/', self.admin_view(_global_search_view), name='global_search'),
+    ]
+    return custom + original_urls
+
+
+admin.AdminSite.get_urls = _custom_get_urls

--- a/rs_systems/admin.py
+++ b/rs_systems/admin.py
@@ -7,6 +7,7 @@ from django.contrib import messages
 from apps.customer_portal.models import CustomerUser
 from apps.technician_portal.models import Technician
 from core.models import Customer
+from rs_systems.admin_dashboard import get_dashboard_context
 
 # Extend the User admin
 class UserAdmin(BaseUserAdmin):
@@ -208,4 +209,25 @@ admin.site.register(User, UserAdmin)
 # Customize admin site
 admin.site.site_header = 'RSWR Systems Administration'
 admin.site.site_title = 'RSWR Admin Portal'
-admin.site.index_title = 'Administration Dashboard' 
+admin.site.index_title = 'Administration Dashboard'
+
+# ── Phase 2: Custom Dashboard ─────────────────────────────────────────────────
+# Wire up custom index template and inject dashboard metrics.
+
+# Point admin to our custom index template
+admin.site.index_template = 'admin/index.html'
+
+# Monkey-patch the index view to inject dashboard context
+_original_index = admin.AdminSite.index
+
+
+def _dashboard_index(self, request, extra_context=None):
+    extra_context = extra_context or {}
+    try:
+        extra_context.update(get_dashboard_context())
+    except Exception:
+        pass  # Never let dashboard errors break the admin
+    return _original_index(self, request, extra_context)
+
+
+admin.AdminSite.index = _dashboard_index

--- a/rs_systems/admin_dashboard.py
+++ b/rs_systems/admin_dashboard.py
@@ -1,0 +1,117 @@
+"""
+Custom Admin Dashboard for RS Systems.
+
+Overrides the default Django admin index view to show real business metrics:
+- Subscription overview (active, trialing, grace period, expired)
+- This month's stats (repairs, invoices, revenue, outstanding)
+- Recent activity (last 10 repairs, last 5 invoices)
+- Quick links to common admin tasks
+
+Author: Amelia
+"""
+
+from django.utils import timezone
+from django.db.models import Sum, Count, Q
+
+
+def get_dashboard_context():
+    """
+    Collect all metrics needed for the admin dashboard.
+    Returns a dict that gets merged into the admin index template context.
+    Gracefully handles missing models/data.
+    """
+    ctx = {}
+
+    # -------------------------------------------------------------------------
+    # Subscription overview
+    # -------------------------------------------------------------------------
+    try:
+        from apps.tenants.models import Tenant
+        now = timezone.now()
+
+        ctx['tenant_active_count'] = Tenant.objects.filter(subscription_status='active').count()
+        ctx['tenant_expired_count'] = Tenant.objects.filter(subscription_status='expired').count()
+        ctx['tenant_canceled_count'] = Tenant.objects.filter(subscription_status='canceled').count()
+
+        # Trialing - expiring within 7 days
+        trial_tenants = Tenant.objects.filter(plan='trial', subscription_status='trialing')
+        ctx['tenant_trial_count'] = trial_tenants.count()
+        ctx['tenant_trial_expiring_soon'] = sum(
+            1 for t in trial_tenants if t.trial_days_remaining <= 7
+        )
+
+        # Grace period
+        ctx['tenant_grace_count'] = sum(
+            1 for t in Tenant.objects.exclude(grace_period_end=None) if t.is_in_grace_period
+        )
+
+        ctx['tenant_total'] = Tenant.objects.count()
+    except Exception:
+        ctx.update({
+            'tenant_active_count': 0, 'tenant_expired_count': 0,
+            'tenant_canceled_count': 0, 'tenant_trial_count': 0,
+            'tenant_trial_expiring_soon': 0, 'tenant_grace_count': 0,
+            'tenant_total': 0,
+        })
+
+    # -------------------------------------------------------------------------
+    # This month's stats
+    # -------------------------------------------------------------------------
+    try:
+        from apps.technician_portal.models import Repair
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        ctx['repairs_this_month'] = Repair.objects.filter(
+            service_date__gte=month_start,
+            queue_status='COMPLETED'
+        ).count()
+    except Exception:
+        ctx['repairs_this_month'] = 0
+
+    try:
+        from apps.billing.models import Invoice
+        ctx['invoices_this_month'] = Invoice.objects.filter(
+            invoice_date__gte=month_start
+        ).count()
+
+        revenue = Invoice.objects.filter(
+            invoice_date__gte=month_start,
+            status__in=['PAID', 'PARTIAL']
+        ).aggregate(total=Sum('amount_paid'))['total'] or 0
+        ctx['revenue_this_month'] = f"${revenue:,.2f}"
+
+        outstanding = Invoice.objects.filter(
+            status__in=['SENT', 'PARTIAL', 'OVERDUE']
+        ).aggregate(
+            due=Sum('total')
+        )['due'] or 0
+        ctx['outstanding_balance'] = f"${outstanding:,.2f}"
+    except Exception:
+        ctx['invoices_this_month'] = 0
+        ctx['revenue_this_month'] = '$0.00'
+        ctx['outstanding_balance'] = '$0.00'
+
+    # -------------------------------------------------------------------------
+    # Recent activity
+    # -------------------------------------------------------------------------
+    try:
+        from apps.technician_portal.models import Repair
+        ctx['recent_repairs'] = (
+            Repair.objects
+            .select_related('customer', 'technician__user', 'tenant')
+            .order_by('-service_date')[:10]
+        )
+    except Exception:
+        ctx['recent_repairs'] = []
+
+    try:
+        from apps.billing.models import Invoice
+        ctx['recent_invoices'] = (
+            Invoice.objects
+            .select_related('customer')
+            .order_by('-invoice_date')[:5]
+        )
+    except Exception:
+        ctx['recent_invoices'] = []
+
+    return ctx

--- a/rs_systems/admin_mixins.py
+++ b/rs_systems/admin_mixins.py
@@ -1,0 +1,61 @@
+"""
+Admin Mixins for RS Systems — Phase 5: Tenant-Aware Filtering
+
+Provides TenantFilterMixin that makes admin views multi-tenant aware:
+- Superusers: see all data across all tenants, plus a tenant list_filter
+- Non-superusers: see only their own tenant's data (via TenantMembership)
+
+Author: Amelia
+"""
+
+
+class TenantFilterMixin:
+    """
+    Mixin for ModelAdmin classes that have a 'tenant' FK.
+
+    Behaviour:
+    - Superusers: full access to all data; 'tenant' is added to list_filter
+    - Non-superusers: queryset is restricted to the user's active tenant(s)
+      via TenantMembership; 'tenant' filter is hidden (would be useless anyway)
+
+    Usage:
+        class RepairAdmin(TenantFilterMixin, admin.ModelAdmin):
+            tenant_field = 'tenant'          # default — override if path differs
+            ...
+    """
+
+    # The ORM field path that reaches the Tenant.
+    # For direct FKs: 'tenant'
+    # For indirect: e.g. 'invoice__customer__tenant'
+    tenant_field: str = 'tenant'
+
+    # ------------------------------------------------------------------ helpers
+
+    def _get_user_tenants(self, request):
+        """Return a queryset of Tenant objects the current user belongs to."""
+        from apps.tenants.models import TenantMembership
+        return (
+            TenantMembership.objects
+            .filter(user=request.user, is_active=True)
+            .values_list('tenant', flat=True)
+        )
+
+    # ------------------------------------------------------------------ overrides
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        tenant_ids = self._get_user_tenants(request)
+        return qs.filter(**{f"{self.tenant_field}__in": tenant_ids})
+
+    def get_list_filter(self, request):
+        filters = list(super().get_list_filter(request))
+        if request.user.is_superuser:
+            # Add 'tenant' filter for superusers if not already present
+            if 'tenant' not in filters and self.tenant_field == 'tenant':
+                filters = ['tenant'] + filters
+        else:
+            # Remove 'tenant' filter for non-superusers
+            filters = [f for f in filters if f != 'tenant']
+        return filters

--- a/rs_systems/urls.py
+++ b/rs_systems/urls.py
@@ -16,6 +16,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
+# Load the admin customizations (dashboard, site header, etc.)
+from rs_systems import admin as _rs_admin_setup  # noqa: F401, E402
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static

--- a/templates/404.html
+++ b/templates/404.html
@@ -57,7 +57,7 @@
 
             <p class="mt-8 text-xs text-gray-400">
                 If you followed a link to get here, please
-                <a href="mailto:support@rockstarwindshield.repair" class="text-blue-500 hover:underline">let us know</a>.
+                <a href="mailto:support@rssystems.io" class="text-blue-500 hover:underline">let us know</a>.
             </p>
         </div>
     </main>

--- a/templates/404.html
+++ b/templates/404.html
@@ -57,7 +57,7 @@
 
             <p class="mt-8 text-xs text-gray-400">
                 If you followed a link to get here, please
-                <a href="mailto:support@rssystems.io" class="text-blue-500 hover:underline">let us know</a>.
+                <a href="mailto:contact@rssystems.io" class="text-blue-500 hover:underline">let us know</a>.
             </p>
         </div>
     </main>

--- a/templates/500.html
+++ b/templates/500.html
@@ -58,7 +58,7 @@
 
             <p class="mt-8 text-xs text-gray-400">
                 If this keeps happening, please
-                <a href="mailto:support@rssystems.io" class="text-blue-500 hover:underline">contact support</a>.
+                <a href="mailto:contact@rssystems.io" class="text-blue-500 hover:underline">contact support</a>.
             </p>
         </div>
     </main>

--- a/templates/500.html
+++ b/templates/500.html
@@ -58,7 +58,7 @@
 
             <p class="mt-8 text-xs text-gray-400">
                 If this keeps happening, please
-                <a href="mailto:support@rockstarwindshield.repair" class="text-blue-500 hover:underline">contact support</a>.
+                <a href="mailto:support@rssystems.io" class="text-blue-500 hover:underline">contact support</a>.
             </p>
         </div>
     </main>

--- a/templates/admin/global_search.html
+++ b/templates/admin/global_search.html
@@ -1,0 +1,200 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}Global Search | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<style>
+  .search-box-wrap {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 20px 0 30px;
+  }
+  .search-box-wrap input[type=text] {
+    flex: 1;
+    padding: 10px 16px;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    max-width: 600px;
+  }
+  .search-box-wrap button {
+    padding: 10px 20px;
+    background: #417690;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+  .search-box-wrap button:hover { background: #2a4c6e; }
+
+  .result-section {
+    margin-bottom: 30px;
+  }
+  .result-section h3 {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #417690;
+    border-bottom: 2px solid #417690;
+    padding-bottom: 6px;
+    margin-bottom: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .result-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .result-table th {
+    background: #f7f8f9;
+    text-align: left;
+    padding: 8px 12px;
+    font-size: 0.82rem;
+    color: #666;
+    border-bottom: 1px solid #e2e8f0;
+  }
+  .result-table td {
+    padding: 8px 12px;
+    font-size: 0.88rem;
+    border-bottom: 1px solid #f0f0f0;
+  }
+  .result-table tr:last-child td { border-bottom: none; }
+  .result-table tr:hover td { background: #f7fbff; }
+  .result-count {
+    font-size: 0.78rem;
+    color: #999;
+    margin-left: 8px;
+    font-weight: normal;
+  }
+  .no-results {
+    color: #999;
+    font-style: italic;
+    padding: 10px 0;
+  }
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    color: white;
+    background: #6c757d;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <h1>🔍 Global Search</h1>
+  <p style="color:#666;">Search across customers, repairs, invoices, and users.</p>
+
+  <form method="get" action="">
+    <div class="search-box-wrap">
+      <input type="text" name="q" value="{{ query }}" placeholder="Type a name, unit number, invoice number, email…" autofocus>
+      <button type="submit">Search</button>
+    </div>
+  </form>
+
+  {% if query %}
+    {% if not results.customers and not results.repairs and not results.invoices and not results.users %}
+      <p class="no-results">No results found for "<strong>{{ query }}</strong>".</p>
+    {% else %}
+
+      {# ── Customers ── #}
+      {% if results.customers %}
+      <div class="result-section">
+        <h3>Customers <span class="result-count">{{ results.customers|length }} result(s)</span></h3>
+        <table class="result-table">
+          <thead><tr><th>Name</th><th>Tenant</th><th>Email</th><th>Phone</th><th></th></tr></thead>
+          <tbody>
+          {% for c in results.customers %}
+            <tr>
+              <td>{{ c.name }}</td>
+              <td>{{ c.tenant.name|default:"—" }}</td>
+              <td>{{ c.email|default:"—" }}</td>
+              <td>{{ c.phone|default:"—" }}</td>
+              <td><a href="/admin/core/customer/{{ c.pk }}/change/">Edit</a></td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+
+      {# ── Repairs ── #}
+      {% if results.repairs %}
+      <div class="result-section">
+        <h3>Repairs <span class="result-count">{{ results.repairs|length }} result(s)</span></h3>
+        <table class="result-table">
+          <thead><tr><th>#</th><th>Tenant</th><th>Customer</th><th>Unit #</th><th>Status</th><th>Date</th><th></th></tr></thead>
+          <tbody>
+          {% for r in results.repairs %}
+            <tr>
+              <td>{{ r.pk }}</td>
+              <td>{{ r.tenant.name|default:"—" }}</td>
+              <td>{{ r.customer.name|default:"—" }}</td>
+              <td>{{ r.unit_number|default:"—" }}</td>
+              <td><span class="badge">{{ r.get_queue_status_display }}</span></td>
+              <td>{{ r.service_date }}</td>
+              <td><a href="/admin/technician_portal/repair/{{ r.pk }}/change/">Edit</a></td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+
+      {# ── Invoices ── #}
+      {% if results.invoices %}
+      <div class="result-section">
+        <h3>Invoices <span class="result-count">{{ results.invoices|length }} result(s)</span></h3>
+        <table class="result-table">
+          <thead><tr><th>Invoice #</th><th>Tenant</th><th>Customer</th><th>Date</th><th>Total</th><th>Status</th><th></th></tr></thead>
+          <tbody>
+          {% for inv in results.invoices %}
+            <tr>
+              <td>{{ inv.invoice_number }}</td>
+              <td>{{ inv.tenant.name|default:"—" }}</td>
+              <td>{{ inv.customer.name|default:"—" }}</td>
+              <td>{{ inv.invoice_date }}</td>
+              <td>${{ inv.total }}</td>
+              <td><span class="badge">{{ inv.get_status_display }}</span></td>
+              <td><a href="/admin/billing/invoice/{{ inv.pk }}/change/">Edit</a></td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+
+      {# ── Users ── #}
+      {% if results.users %}
+      <div class="result-section">
+        <h3>Users <span class="result-count">{{ results.users|length }} result(s)</span></h3>
+        <table class="result-table">
+          <thead><tr><th>Username</th><th>Full Name</th><th>Email</th><th>Staff?</th><th></th></tr></thead>
+          <tbody>
+          {% for u in results.users %}
+            <tr>
+              <td>{{ u.username }}</td>
+              <td>{{ u.get_full_name|default:"—" }}</td>
+              <td>{{ u.email|default:"—" }}</td>
+              <td>{% if u.is_staff %}✓{% else %}—{% endif %}</td>
+              <td><a href="/admin/auth/user/{{ u.pk }}/change/">Edit</a></td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+
+    {% endif %}
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,0 +1,347 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block title %}{% trans 'Dashboard' %} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<style>
+  /* ── Dashboard Layout ───────────────────────────── */
+  #dashboard-root {
+    padding: 20px 0;
+  }
+
+  /* ── Section headers ────────────────────────────── */
+  .dash-section-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #4299E1;
+    border-bottom: 2px solid #4299E1;
+    padding-bottom: 6px;
+    margin: 28px 0 16px;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+
+  /* ── Metric cards ───────────────────────────────── */
+  .dash-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 14px;
+    margin-bottom: 8px;
+  }
+
+  .dash-card {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 18px 16px 14px;
+    box-shadow: 0 1px 3px rgba(0,0,0,.06);
+    transition: box-shadow .15s;
+  }
+  .dash-card:hover {
+    box-shadow: 0 4px 12px rgba(66,153,225,.15);
+  }
+
+  .dash-card-label {
+    font-size: 0.73rem;
+    font-weight: 600;
+    color: #718096;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 8px;
+  }
+
+  .dash-card-value {
+    font-size: 2rem;
+    font-weight: 800;
+    color: #2d3748;
+    line-height: 1;
+  }
+
+  .dash-card-sub {
+    font-size: 0.78rem;
+    color: #a0aec0;
+    margin-top: 6px;
+  }
+
+  /* colour accents */
+  .dash-card.accent-blue  .dash-card-value { color: #4299E1; }
+  .dash-card.accent-green .dash-card-value { color: #38a169; }
+  .dash-card.accent-orange .dash-card-value { color: #dd6b20; }
+  .dash-card.accent-red   .dash-card-value { color: #e53e3e; }
+  .dash-card.accent-gray  .dash-card-value { color: #718096; }
+
+  /* ── Tables ─────────────────────────────────────── */
+  .dash-table-wrap {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,.06);
+    margin-bottom: 20px;
+  }
+
+  .dash-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+  }
+
+  .dash-table th {
+    background: #4299E1;
+    color: #fff;
+    padding: 9px 12px;
+    text-align: left;
+    font-weight: 600;
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .dash-table td {
+    padding: 8px 12px;
+    border-bottom: 1px solid #f0f4f8;
+    color: #4a5568;
+  }
+
+  .dash-table tr:last-child td {
+    border-bottom: none;
+  }
+
+  .dash-table tr:hover td {
+    background: #ebf8ff;
+  }
+
+  /* status badges */
+  .status-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .status-COMPLETED, .status-PAID   { background: #c6f6d5; color: #276749; }
+  .status-IN_PROGRESS, .status-SENT { background: #bee3f8; color: #2b6cb0; }
+  .status-PENDING, .status-PARTIAL  { background: #feebc8; color: #c05621; }
+  .status-DENIED, .status-OVERDUE   { background: #fed7d7; color: #9b2c2c; }
+  .status-REQUESTED, .status-DRAFT  { background: #e2e8f0; color: #4a5568; }
+
+  /* ── Quick links ─────────────────────────────────── */
+  .dash-quicklinks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 20px;
+  }
+
+  .dash-quicklink {
+    background: #4299E1;
+    color: #fff !important;
+    border-radius: 6px;
+    padding: 8px 16px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background .15s;
+  }
+  .dash-quicklink:hover {
+    background: #2b6cb0;
+    color: #fff !important;
+  }
+  .dash-quicklink.ghost {
+    background: transparent;
+    border: 2px solid #4299E1;
+    color: #4299E1 !important;
+  }
+  .dash-quicklink.ghost:hover {
+    background: #ebf8ff;
+  }
+
+  /* ── Two-column layout for recent activity ────── */
+  .dash-two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+  }
+
+  @media (max-width: 900px) {
+    .dash-two-col { grid-template-columns: 1fr; }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="dashboard-root">
+
+  <!-- ── Subscription Overview ─────────────────────── -->
+  <h2 class="dash-section-title">📊 Subscription Overview</h2>
+  <div class="dash-cards">
+    <div class="dash-card accent-green">
+      <div class="dash-card-label">Active</div>
+      <div class="dash-card-value">{{ tenant_active_count }}</div>
+      <div class="dash-card-sub">paying tenants</div>
+    </div>
+    <div class="dash-card accent-blue">
+      <div class="dash-card-label">Trialing</div>
+      <div class="dash-card-value">{{ tenant_trial_count }}</div>
+      <div class="dash-card-sub">
+        {% if tenant_trial_expiring_soon %}
+          ⚠️ {{ tenant_trial_expiring_soon }} expiring in 7 days
+        {% else %}
+          none expiring soon
+        {% endif %}
+      </div>
+    </div>
+    <div class="dash-card accent-orange">
+      <div class="dash-card-label">Grace Period</div>
+      <div class="dash-card-value">{{ tenant_grace_count }}</div>
+      <div class="dash-card-sub">read-only access</div>
+    </div>
+    <div class="dash-card accent-red">
+      <div class="dash-card-label">Expired</div>
+      <div class="dash-card-value">{{ tenant_expired_count }}</div>
+      <div class="dash-card-sub">+ {{ tenant_canceled_count }} canceled</div>
+    </div>
+    <div class="dash-card accent-gray">
+      <div class="dash-card-label">Total Tenants</div>
+      <div class="dash-card-value">{{ tenant_total }}</div>
+      <div class="dash-card-sub">all time</div>
+    </div>
+  </div>
+
+  <!-- ── This Month ────────────────────────────────── -->
+  <h2 class="dash-section-title">📅 This Month</h2>
+  <div class="dash-cards">
+    <div class="dash-card accent-blue">
+      <div class="dash-card-label">Repairs Completed</div>
+      <div class="dash-card-value">{{ repairs_this_month }}</div>
+    </div>
+    <div class="dash-card accent-blue">
+      <div class="dash-card-label">Invoices Generated</div>
+      <div class="dash-card-value">{{ invoices_this_month }}</div>
+    </div>
+    <div class="dash-card accent-green">
+      <div class="dash-card-label">Revenue Collected</div>
+      <div class="dash-card-value" style="font-size:1.5rem;">{{ revenue_this_month }}</div>
+    </div>
+    <div class="dash-card accent-orange">
+      <div class="dash-card-label">Outstanding Balance</div>
+      <div class="dash-card-value" style="font-size:1.5rem;">{{ outstanding_balance }}</div>
+    </div>
+  </div>
+
+  <!-- ── Recent Activity ───────────────────────────── -->
+  <h2 class="dash-section-title">⚡ Recent Activity</h2>
+  <div class="dash-two-col">
+
+    <!-- Recent Repairs -->
+    <div>
+      <div class="dash-table-wrap">
+        <table class="dash-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Customer</th>
+              <th>Unit</th>
+              <th>Tech</th>
+              <th>Status</th>
+              <th>Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for repair in recent_repairs %}
+            <tr>
+              <td><a href="{% url 'admin:technician_portal_repair_change' repair.id %}">{{ repair.id }}</a></td>
+              <td>{{ repair.customer.name|default:"—" }}</td>
+              <td>{{ repair.unit_number|default:"—" }}</td>
+              <td>{% if repair.technician %}{{ repair.technician.user.get_full_name|default:repair.technician.user.username }}{% else %}—{% endif %}</td>
+              <td><span class="status-badge status-{{ repair.queue_status }}">{{ repair.get_queue_status_display }}</span></td>
+              <td>{{ repair.service_date|date:"M d" }}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="6" style="color:#a0aec0;text-align:center;padding:20px;">No repairs found</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <a href="{% url 'admin:technician_portal_repair_changelist' %}" class="dash-quicklink ghost" style="font-size:.8rem;">View all repairs →</a>
+    </div>
+
+    <!-- Recent Invoices -->
+    <div>
+      <div class="dash-table-wrap">
+        <table class="dash-table">
+          <thead>
+            <tr>
+              <th>Invoice #</th>
+              <th>Customer</th>
+              <th>Total</th>
+              <th>Status</th>
+              <th>Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for invoice in recent_invoices %}
+            <tr>
+              <td><a href="{% url 'admin:billing_invoice_change' invoice.id %}">{{ invoice.invoice_number }}</a></td>
+              <td>{{ invoice.customer.name|default:"—" }}</td>
+              <td>${{ invoice.total|floatformat:2 }}</td>
+              <td><span class="status-badge status-{{ invoice.status }}">{{ invoice.get_status_display }}</span></td>
+              <td>{{ invoice.invoice_date|date:"M d" }}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="5" style="color:#a0aec0;text-align:center;padding:20px;">No invoices found</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <a href="{% url 'admin:billing_invoice_changelist' %}" class="dash-quicklink ghost" style="font-size:.8rem;">View all invoices →</a>
+    </div>
+  </div>
+
+  <!-- ── Quick Links ───────────────────────────────── -->
+  <h2 class="dash-section-title">🔗 Quick Links</h2>
+  <div class="dash-quicklinks">
+    <a href="{% url 'admin:tenants_tenant_changelist' %}" class="dash-quicklink">🏢 Tenants</a>
+    <a href="{% url 'admin:tenants_tenant_add' %}" class="dash-quicklink ghost">+ New Tenant</a>
+    <a href="{% url 'admin:technician_portal_repair_changelist' %}" class="dash-quicklink">🔧 Repairs</a>
+    <a href="{% url 'admin:billing_invoice_changelist' %}" class="dash-quicklink">🧾 Invoices</a>
+    <a href="{% url 'admin:auth_user_changelist' %}" class="dash-quicklink">👤 Users</a>
+    <a href="{% url 'admin:core_customer_changelist' %}" class="dash-quicklink">🏭 Customers</a>
+    <a href="{% url 'admin:tenants_subscriptionplan_changelist' %}" class="dash-quicklink">💳 Plans</a>
+    <a href="{% url 'admin:billing_billingconfig_changelist' %}" class="dash-quicklink ghost">⚙️ Billing Config</a>
+    <a href="{% url 'admin:core_notification_changelist' %}" class="dash-quicklink ghost">🔔 Notifications</a>
+  </div>
+
+  <!-- ── Standard app/model index (collapsible) ──── -->
+  <details style="margin-top:28px;">
+    <summary style="cursor:pointer; color:#4299E1; font-weight:600; font-size:.95rem; margin-bottom:12px;">
+      📋 All Registered Models
+    </summary>
+    {% if app_list %}
+      {% for app in app_list %}
+      <div style="margin-bottom:16px;">
+        <h3 style="font-size:.9rem; font-weight:700; color:#2d3748; margin-bottom:6px;">{{ app.name }}</h3>
+        <ul style="list-style:none; padding:0; margin:0; display:flex; flex-wrap:wrap; gap:6px;">
+          {% for model in app.models %}
+          <li>
+            {% if model.admin_url %}
+              <a href="{{ model.admin_url }}" style="color:#4299E1; font-size:.83rem; padding:3px 8px; border:1px solid #bee3f8; border-radius:4px; text-decoration:none; background:#f0f8ff;">
+                {{ model.name }}
+              </a>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endfor %}
+    {% else %}
+      <p>{% trans "You don't have permission to view or edit anything." %}</p>
+    {% endif %}
+  </details>
+
+</div>
+{% endblock %}

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -176,6 +176,22 @@
 {% block content %}
 <div id="dashboard-root">
 
+  <!-- ── Global Search ─────────────────────────────── -->
+  <div style="margin-bottom:24px;">
+    <form method="get" action="{% url 'admin:global_search' %}">
+      <div style="display:flex; gap:10px; align-items:center; max-width:600px;">
+        <input type="text" name="q" placeholder="🔍 Search customers, repairs, invoices, users…"
+               style="flex:1; padding:10px 16px; border:1px solid #ccd; border-radius:6px; font-size:.93rem;">
+        <button type="submit"
+                style="padding:10px 20px; background:#417690; color:white; border:none; border-radius:6px; cursor:pointer; font-size:.93rem;">
+          Search
+        </button>
+        <a href="{% url 'admin:admin_logentry_changelist' %}"
+           style="font-size:.82rem; color:#718096; white-space:nowrap; text-decoration:none;">📋 Audit Log</a>
+      </div>
+    </form>
+  </div>
+
   <!-- ── Subscription Overview ─────────────────────── -->
   <h2 class="dash-section-title">📊 Subscription Overview</h2>
   <div class="dash-cards">
@@ -314,6 +330,8 @@
     <a href="{% url 'admin:tenants_subscriptionplan_changelist' %}" class="dash-quicklink">💳 Plans</a>
     <a href="{% url 'admin:billing_billingconfig_changelist' %}" class="dash-quicklink ghost">⚙️ Billing Config</a>
     <a href="{% url 'admin:core_notification_changelist' %}" class="dash-quicklink ghost">🔔 Notifications</a>
+    <a href="{% url 'admin:global_search' %}" class="dash-quicklink">🔍 Global Search</a>
+    <a href="{% url 'admin:admin_logentry_changelist' %}" class="dash-quicklink ghost">📋 Audit Log</a>
   </div>
 
   <!-- ── Standard app/model index (collapsible) ──── -->

--- a/templates/base_app.html
+++ b/templates/base_app.html
@@ -90,7 +90,7 @@
                     <span class="text-sm text-gray-500 hidden sm:inline truncate max-w-[200px]" title="{{ tenant.name }}">{{ tenant.name }}</span>
                     {% if is_owner_or_manager %}
                     <span class="hidden sm:inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold
-                        {% if tenant.plan == 'trial' %}bg-amber-100 text-amber-800
+                        {% if tenant.plan == 'trial' %}border border-blue-300 text-blue-600 bg-white
                         {% elif tenant.plan == 'starter' %}bg-blue-100 text-blue-800
                         {% elif tenant.plan == 'pro' %}bg-green-100 text-green-800
                         {% elif tenant.plan == 'enterprise' %}bg-purple-100 text-purple-800

--- a/templates/billing/payment_cancelled.html
+++ b/templates/billing/payment_cancelled.html
@@ -36,7 +36,7 @@
                 If you're experiencing issues, please contact us.
             </p>
             <div class="flex flex-col sm:flex-row gap-3 justify-center">
-                <a href="mailto:info@rssystems.io" class="inline-block border border-gray-300 text-gray-700 px-6 py-3 rounded-lg font-medium hover:bg-gray-50 transition-colors">
+                <a href="mailto:contact@rssystems.io" class="inline-block border border-gray-300 text-gray-700 px-6 py-3 rounded-lg font-medium hover:bg-gray-50 transition-colors">
                     Contact Us
                 </a>
                 <a href="/" class="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors">

--- a/templates/billing/payment_complete.html
+++ b/templates/billing/payment_complete.html
@@ -34,7 +34,7 @@
             <div class="bg-gray-50 rounded-lg p-4 mb-6">
                 <p class="text-sm text-gray-500">
                     If you have any questions about your invoice, please contact us at
-                    <a href="mailto:info@rssystems.io" class="text-blue-600 hover:underline">info@rssystems.io</a>
+                    <a href="mailto:contact@rssystems.io" class="text-blue-600 hover:underline">contact@rssystems.io</a>
                 </p>
             </div>
             <a href="/" class="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors">

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -457,7 +457,7 @@
                     <a href="/signup/" class="hover:text-white transition-colors">Sign Up</a>
                     <a href="/terms/" class="hover:text-white transition-colors">Terms of Service</a>
                     <a href="/privacy/" class="hover:text-white transition-colors">Privacy Policy</a>
-                    <a href="mailto:support@rs-systems.io" class="hover:text-white transition-colors">Contact</a>
+                    <a href="mailto:contact@rssystems.io" class="hover:text-white transition-colors">Contact</a>
                 </div>
             </div>
             <div class="border-t border-gray-800 mt-8 pt-8 text-center text-sm">

--- a/templates/saas/owner_settings.html
+++ b/templates/saas/owner_settings.html
@@ -103,15 +103,23 @@
                 <div class="flex-1 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 text-sm text-gray-700 font-mono break-all" id="joinLinkText">
                     {{ shop_join_url }}
                 </div>
-                <button onclick="copyJoinLink()" id="copyBtn"
-                    class="inline-flex items-center justify-center px-5 py-2.5 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:bg-emerald-700 transition-colors shadow-sm whitespace-nowrap">
-                    <i class="fas fa-copy mr-2" id="copyIcon"></i>
-                    <span id="copyBtnText">Copy Link</span>
-                </button>
+                <div class="flex gap-2">
+                    <a href="{{ shop_join_url }}" target="_blank" rel="noopener noreferrer" id="previewBtn"
+                        class="inline-flex items-center justify-center px-4 py-2.5 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-50 transition-colors shadow-sm whitespace-nowrap">
+                        <i class="fas fa-eye mr-2"></i>
+                        Preview
+                    </a>
+                    <button onclick="copyJoinLink()" id="copyBtn"
+                        class="inline-flex items-center justify-center px-5 py-2.5 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:bg-emerald-700 transition-colors shadow-sm whitespace-nowrap">
+                        <i class="fas fa-copy mr-2" id="copyIcon"></i>
+                        <span id="copyBtnText">Copy Link</span>
+                    </button>
+                </div>
             </div>
             <p class="text-xs text-gray-500 mt-3">
                 <i class="fas fa-info-circle mr-1"></i>
                 Customers who visit this link can sign up to track repairs, approve work orders, and view invoices.
+                Use <strong>Preview</strong> to see exactly what your customers will see when they sign up.
             </p>
         </div>
     </div>

--- a/templates/saas/owner_settings.html
+++ b/templates/saas/owner_settings.html
@@ -255,10 +255,10 @@
                             {% else %}bg-gray-100 text-gray-800{% endif %}">
                             {{ member.get_role_display }}
                         </span>
-                        {% if member.technician_record %}
+                        {% if member.technician_record and member.role != 'owner' %}
                             {% if member.technician_record.can_repair %}
                             <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
-                                <i class="fas fa-tools mr-1 text-[10px]"></i>Repairs
+                                <i class="fas fa-wrench mr-1 text-[10px]"></i>Repairs
                             </span>
                             {% endif %}
                             {% if member.technician_record.can_replace %}
@@ -809,7 +809,7 @@
                         <div class="space-y-2">
                             <label class="flex items-center gap-2 cursor-pointer">
                                 <input type="checkbox" name="can_repair" checked class="h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500">
-                                <span class="text-sm text-gray-700"><i class="fas fa-tools text-amber-500 mr-1"></i>Can do repairs</span>
+                                <span class="text-sm text-gray-700"><i class="fas fa-wrench text-amber-500 mr-1"></i>Can do repairs</span>
                             </label>
                             <label class="flex items-center gap-2 cursor-pointer">
                                 <input type="checkbox" name="can_replace" class="h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500">

--- a/templates/saas/subscription_blocked.html
+++ b/templates/saas/subscription_blocked.html
@@ -23,8 +23,8 @@
             </a>
             <p class="mt-4 text-sm text-gray-500">
                 Questions? Email us at
-                <a href="mailto:support@rssystems.io" class="text-blue-600 hover:underline">
-                    support@rssystems.io
+                <a href="mailto:contact@rssystems.io" class="text-blue-600 hover:underline">
+                    contact@rssystems.io
                 </a>
             </p>
         </div>

--- a/templates/saas/subscription_blocked.html
+++ b/templates/saas/subscription_blocked.html
@@ -23,8 +23,8 @@
             </a>
             <p class="mt-4 text-sm text-gray-500">
                 Questions? Email us at
-                <a href="mailto:support@rockstarwindshield.repair" class="text-blue-600 hover:underline">
-                    support@rockstarwindshield.repair
+                <a href="mailto:support@rssystems.io" class="text-blue-600 hover:underline">
+                    support@rssystems.io
                 </a>
             </p>
         </div>

--- a/templates/saas/terms_of_service.html
+++ b/templates/saas/terms_of_service.html
@@ -118,7 +118,7 @@
             If you have questions about these Terms, please contact us at:
         </p>
         <p class="text-gray-700 mb-4">
-            <strong>Email:</strong> support@rssystems.io<br>
+            <strong>Email:</strong> contact@rssystems.io<br>
             <strong>Website:</strong> rssystems.io
         </p>
 

--- a/templates/technician_portal/customer_details.html
+++ b/templates/technician_portal/customer_details.html
@@ -64,6 +64,18 @@
                             <a href="mailto:{{ customer.email }}" class="text-sm text-blue-600 hover:text-blue-800">{{ customer.email }}</a>
                         </div>
                     </div>
+                    {% elif can_edit_customer %}
+                    <div class="flex items-start gap-3">
+                        <div class="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                            <i class="fas fa-envelope text-gray-300 text-sm"></i>
+                        </div>
+                        <div>
+                            <p class="text-xs text-gray-500 uppercase tracking-wide">Email</p>
+                            <a href="{% url 'edit_customer' customer.id %}" class="text-sm text-gray-400 hover:text-blue-600 transition-colors">
+                                <i class="fas fa-plus text-xs mr-1"></i>Add email address
+                            </a>
+                        </div>
+                    </div>
                     {% endif %}
 
                     {% if customer.phone %}
@@ -74,6 +86,18 @@
                         <div>
                             <p class="text-xs text-gray-500 uppercase tracking-wide">Phone</p>
                             <a href="tel:{{ customer.phone }}" class="text-sm text-gray-900">{{ customer.phone }}</a>
+                        </div>
+                    </div>
+                    {% elif can_edit_customer %}
+                    <div class="flex items-start gap-3">
+                        <div class="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                            <i class="fas fa-phone text-gray-300 text-sm"></i>
+                        </div>
+                        <div>
+                            <p class="text-xs text-gray-500 uppercase tracking-wide">Phone</p>
+                            <a href="{% url 'edit_customer' customer.id %}" class="text-sm text-gray-400 hover:text-blue-600 transition-colors">
+                                <i class="fas fa-plus text-xs mr-1"></i>Add phone number
+                            </a>
                         </div>
                     </div>
                     {% endif %}
@@ -94,7 +118,7 @@
                     </div>
                     {% endif %}
 
-                    {% if not customer.email and not customer.phone and not customer.address %}
+                    {% if not customer.email and not customer.phone and not customer.address and not can_edit_customer %}
                     <p class="text-sm text-gray-500 italic">No contact information on file.</p>
                     {% endif %}
 

--- a/tests/bug_fixes/test_multi_break_repair.py
+++ b/tests/bug_fixes/test_multi_break_repair.py
@@ -1092,6 +1092,7 @@ class CustomerPortalBatchApprovalTestCase(TestCase):
     def test_mixed_batch_and_individual_repairs(self):
         """Test that dashboard correctly separates batch and individual repairs"""
         # Create an individual (non-batch) repair
+        # Must include tenant= so it passes the base_qs tenant filter in customer_dashboard
         individual_repair = Repair.objects.create(
             customer=self.customer,
             unit_number='2002',
@@ -1099,7 +1100,8 @@ class CustomerPortalBatchApprovalTestCase(TestCase):
             repair_date=timezone.now(),
             cost=50,
             queue_status='PENDING',
-            technician=self.technician
+            technician=self.technician,
+            tenant=self.tenant,
             # No repair_batch_id - this is individual
         )
 

--- a/tests/bug_fixes/test_ux003_portal_preview.py
+++ b/tests/bug_fixes/test_ux003_portal_preview.py
@@ -1,0 +1,118 @@
+"""
+Regression tests for UX-003: Customer Portal link has no "what customers see" context.
+
+Root cause: The Customer Portal section in Owner Settings only showed a shareable
+link with a small gray helper text. Owners had no way to preview what customers
+actually see when they visit the signup page.
+
+Fix:
+  - Added a "Preview" button (opens shop_join_url in a new tab) alongside Copy Link.
+  - Expanded helper text to mention the Preview button's purpose.
+  - `shop_join_url` is already in context — no view changes needed.
+"""
+from decimal import Decimal
+
+from django.test import TestCase, Client, override_settings
+from django.contrib.auth.models import User
+
+from apps.tenants.models import Tenant, TenantMembership, SubscriptionPlan
+
+TEST_OVERRIDES = {
+    'ALLOWED_HOSTS': ['*'],
+    'CACHES': {'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}},
+}
+
+
+def _make_tenant_with_owner(name, slug, plan_slug='trial'):
+    plan, _ = SubscriptionPlan.objects.get_or_create(
+        slug=plan_slug,
+        defaults={
+            'name': plan_slug.title(),
+            'monthly_price': Decimal('0.00'),
+            'trial_days': 30,
+            'display_order': 0,
+        },
+    )
+    user = User.objects.create_user(
+        slug, f'{slug}@test.com', 'testpass123',
+        first_name='Test', last_name='Owner',
+    )
+    tenant = Tenant.objects.create(
+        name=name, slug=slug, subdomain=slug, owner=user,
+        subscription_plan=plan,
+    )
+    TenantMembership.objects.create(tenant=tenant, user=user, role='owner')
+    return user, tenant
+
+
+@override_settings(**TEST_OVERRIDES)
+class PortalPreviewContextTest(TestCase):
+    """Verify that owner_settings view includes shop_join_url in context."""
+
+    def setUp(self):
+        self.user, self.tenant = _make_tenant_with_owner('Preview Co', 'previewco')
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def test_shop_join_url_in_context(self):
+        """shop_join_url must be present in owner settings context."""
+        resp = self.client.get('/owner/settings/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('shop_join_url', resp.context)
+
+    def test_shop_join_url_contains_tenant_slug(self):
+        """shop_join_url should contain the tenant slug."""
+        resp = self.client.get('/owner/settings/')
+        self.assertEqual(resp.status_code, 200)
+        shop_join_url = resp.context['shop_join_url']
+        self.assertIn('previewco', shop_join_url)
+
+    def test_shop_join_url_contains_join_path(self):
+        """shop_join_url should reference the /join/ route."""
+        resp = self.client.get('/owner/settings/')
+        self.assertEqual(resp.status_code, 200)
+        shop_join_url = resp.context['shop_join_url']
+        self.assertIn('/join/', shop_join_url)
+
+
+@override_settings(**TEST_OVERRIDES)
+class PortalPreviewTemplateTest(TestCase):
+    """Verify that the Customer Portal section renders the Preview button."""
+
+    def setUp(self):
+        self.user, self.tenant = _make_tenant_with_owner('Preview Test Shop', 'previewshop')
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def test_preview_button_renders(self):
+        """The 'Preview' button (with id=previewBtn) must appear in the settings page."""
+        resp = self.client.get('/owner/settings/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'previewBtn')
+
+    def test_preview_button_links_to_join_url(self):
+        """Preview button href must reference the shop's join URL."""
+        resp = self.client.get('/owner/settings/')
+        self.assertEqual(resp.status_code, 200)
+        # The rendered page should contain a link to /join/<slug>/
+        self.assertContains(resp, '/join/previewshop/')
+
+    def test_preview_button_opens_new_tab(self):
+        """Preview button should have target="_blank" to open in a new tab."""
+        resp = self.client.get('/owner/settings/')
+        self.assertEqual(resp.status_code, 200)
+        content = resp.content.decode()
+        self.assertIn('target="_blank"', content)
+
+    def test_copy_link_button_still_renders(self):
+        """Copy Link button must still exist after adding the Preview button."""
+        resp = self.client.get('/owner/settings/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'copyBtn')
+        self.assertContains(resp, 'Copy Link')
+
+    def test_preview_helper_text_updated(self):
+        """Helper text should mention 'Preview' to guide owners."""
+        resp = self.client.get('/owner/settings/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'Preview')

--- a/tests/bug_fixes/test_ux007_customer_phone.py
+++ b/tests/bug_fixes/test_ux007_customer_phone.py
@@ -1,0 +1,252 @@
+"""
+Regression tests for UX-007: Customer detail page missing phone number field.
+
+UX-007 — Customer detail page missing phone number field
+  Where: /tech/customers/<id>/
+  What: Only email is shown in the contact info card. No phone number displayed
+        even though phone is collected during customer creation.
+  Root cause: The template conditionally rendered phone only when populated, but
+              gave no indication or CTA to add it when missing. Admins/managers
+              viewing a customer with no phone saw nothing — making it look like
+              the field didn't exist at all.
+  Fix: When `can_edit_customer` is True and phone (or email) is absent, render
+       a faded "Add phone number" / "Add email address" link pointing to the
+       customer edit page. When the contact info section is fully empty and the
+       user CANNOT edit, show the "No contact information on file." fallback.
+"""
+
+import os
+from decimal import Decimal
+from django.test import TestCase, Client, override_settings
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from apps.tenants.models import Tenant, TenantMembership, SubscriptionPlan
+from apps.technician_portal.models import Technician
+from core.models import Customer
+
+TEST_OVERRIDES = {
+    'ALLOWED_HOSTS': ['*'],
+    'CACHES': {'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}},
+}
+
+TEMPLATE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    'templates',
+)
+
+
+def _read_template(*path_parts):
+    path = os.path.join(TEMPLATE_DIR, *path_parts)
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def _make_tenant_with_owner(name, username, plan_slug='trial'):
+    plan, _ = SubscriptionPlan.objects.get_or_create(
+        slug=plan_slug,
+        defaults={
+            'name': plan_slug.title(),
+            'monthly_price': Decimal('0.00'),
+            'trial_days': 30,
+            'display_order': 0,
+        },
+    )
+    user = User.objects.create_user(
+        username, f'{username}@test.com', 'testpass123',
+        first_name='Test', last_name='Owner',
+    )
+    tenant = Tenant.objects.create(
+        name=name, slug=username, subdomain=username, owner=user,
+        subscription_plan=plan,
+    )
+    TenantMembership.objects.create(tenant=tenant, user=user, role='owner')
+    return user, tenant
+
+
+# ---------------------------------------------------------------------------
+# Template source checks (fast, no DB required)
+# ---------------------------------------------------------------------------
+
+class CustomerDetailPhoneTemplateTest(TestCase):
+    """Verify template source contains phone display + add-CTA logic."""
+
+    def _content(self):
+        return _read_template('technician_portal', 'customer_details.html')
+
+    def test_phone_displayed_when_present(self):
+        """Template must render phone when customer.phone is truthy."""
+        content = self._content()
+        self.assertIn(
+            'href="tel:{{ customer.phone }}"',
+            content,
+            "customer_details.html must render a tel: link when customer.phone exists (UX-007).",
+        )
+
+    def test_add_phone_cta_when_empty_and_can_edit(self):
+        """
+        When phone is absent and the user can edit the customer, the template
+        must render an 'Add phone number' link pointing to the edit page.
+        """
+        content = self._content()
+        self.assertIn(
+            'Add phone number',
+            content,
+            "customer_details.html must show an 'Add phone number' CTA when phone is missing "
+            "and can_edit_customer is True (UX-007).",
+        )
+
+    def test_add_phone_cta_links_to_edit_page(self):
+        """The 'Add phone number' CTA must link to the edit_customer URL."""
+        content = self._content()
+        # The CTA should be inside a block guarded by can_edit_customer
+        # and href should reference edit_customer url tag
+        self.assertIn(
+            "url 'edit_customer' customer.id",
+            content,
+            "customer_details.html 'Add phone number' CTA must href to {% url 'edit_customer' customer.id %} (UX-007).",
+        )
+
+    def test_add_email_cta_when_empty_and_can_edit(self):
+        """
+        Similarly, when email is absent and the user can edit, the template
+        must render an 'Add email address' link.
+        """
+        content = self._content()
+        self.assertIn(
+            'Add email address',
+            content,
+            "customer_details.html must show an 'Add email address' CTA when email is missing "
+            "and can_edit_customer is True (UX-007).",
+        )
+
+    def test_no_contact_fallback_still_present(self):
+        """
+        'No contact information on file.' fallback must still exist for
+        non-editors viewing customers with no contact data.
+        """
+        content = self._content()
+        self.assertIn(
+            'No contact information on file.',
+            content,
+            "customer_details.html must still have 'No contact information on file.' "
+            "fallback for non-editor views (UX-007).",
+        )
+
+    def test_phone_block_guarded_by_can_edit_customer(self):
+        """
+        The 'Add phone' CTA block must be wrapped in {% elif can_edit_customer %}
+        so it only appears for users with edit rights.
+        """
+        content = self._content()
+        self.assertIn(
+            'elif can_edit_customer',
+            content,
+            "customer_details.html 'Add phone/email' CTAs must be gated by "
+            "{% elif can_edit_customer %} — read-only users should not see them (UX-007).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# View / HTTP tests (requires DB)
+# ---------------------------------------------------------------------------
+
+@override_settings(**TEST_OVERRIDES)
+class CustomerDetailPhoneViewTest(TestCase):
+    """HTTP-level tests for the customer detail page phone/email display."""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner, self.tenant = _make_tenant_with_owner('Acme Glass', 'acmeglass')
+        # Customer WITH phone and email
+        self.customer_full = Customer.objects.create(
+            tenant=self.tenant,
+            name='Fleet With Phone',
+            email='fleet@example.com',
+            phone='+15551234567',
+        )
+        # Customer WITHOUT phone or email
+        self.customer_empty = Customer.objects.create(
+            tenant=self.tenant,
+            name='Fleet No Contact',
+        )
+
+    def _login(self):
+        self.client.force_login(self.owner)
+        session = self.client.session
+        session['tenant_id'] = self.tenant.id
+        session.save()
+
+    def test_phone_shown_for_customer_with_phone(self):
+        """When customer has a phone, the tel: link should appear in response."""
+        self._login()
+        url = reverse('customer_detail', args=[self.customer_full.id])
+        resp = self.client.get(url, SERVER_NAME='acmeglass.testserver')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'tel:+15551234567')
+
+    def test_email_shown_for_customer_with_email(self):
+        """When customer has an email, the mailto: link should appear."""
+        self._login()
+        url = reverse('customer_detail', args=[self.customer_full.id])
+        resp = self.client.get(url, SERVER_NAME='acmeglass.testserver')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'mailto:fleet@example.com')
+
+    def test_add_phone_cta_shown_when_phone_missing_for_owner(self):
+        """
+        When an admin/owner views a customer with no phone, the 'Add phone number'
+        CTA should appear in the response.
+        """
+        self._login()
+        url = reverse('customer_detail', args=[self.customer_empty.id])
+        resp = self.client.get(url, SERVER_NAME='acmeglass.testserver')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(
+            resp,
+            'Add phone number',
+            msg_prefix="Owner viewing customer with no phone should see 'Add phone number' CTA (UX-007).",
+        )
+
+    def test_add_email_cta_shown_when_email_missing_for_owner(self):
+        """
+        When an admin/owner views a customer with no email, the 'Add email address'
+        CTA should appear.
+        """
+        self._login()
+        url = reverse('customer_detail', args=[self.customer_empty.id])
+        resp = self.client.get(url, SERVER_NAME='acmeglass.testserver')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(
+            resp,
+            'Add email address',
+            msg_prefix="Owner viewing customer with no email should see 'Add email address' CTA (UX-007).",
+        )
+
+    def test_add_phone_cta_not_shown_for_technician_without_edit_rights(self):
+        """
+        A regular technician (non-manager, non-admin) cannot edit customer info,
+        so the 'Add phone number' CTA must NOT appear in their response.
+        """
+        tech_user = User.objects.create_user(
+            'techguy', 'tech@test.com', 'testpass123',
+            first_name='Tech', last_name='Guy',
+        )
+        TenantMembership.objects.create(tenant=self.tenant, user=tech_user, role='technician')
+        Technician.objects.create(
+            user=tech_user, tenant=self.tenant,
+            is_active=True, is_manager=False,
+        )
+        self.client.force_login(tech_user)
+        session = self.client.session
+        session['tenant_id'] = self.tenant.id
+        session.save()
+
+        url = reverse('customer_detail', args=[self.customer_empty.id])
+        resp = self.client.get(url, SERVER_NAME='acmeglass.testserver')
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(
+            resp,
+            'Add phone number',
+            msg_prefix="Regular tech should NOT see 'Add phone number' CTA (UX-007).",
+        )

--- a/tests/bug_fixes/test_ux009_team_role_badges.py
+++ b/tests/bug_fixes/test_ux009_team_role_badges.py
@@ -1,0 +1,159 @@
+"""
+Regression tests for UX-009: Team Settings "Repairs" role badge on owners.
+
+Root cause:
+  - Owner-role team members were showing "Repairs" and "Replacements" ability badges
+    in Settings → Team, alongside the "Owner" role badge.
+  - Owners have all permissions by definition; showing ability badges for them is
+    redundant and visually noisy.
+  - The "Repairs" icon also used `fa-tools` (described as scissors-like by reviewer).
+
+Fix (owner_settings.html):
+  - Wrapped ability badge block in `{% if member.role != 'owner' %}` guard.
+  - Changed Repairs badge icon from `fa-tools` to `fa-wrench` for clarity.
+  - Ability badges now only render for technician / manager / viewer roles.
+"""
+from decimal import Decimal
+
+from django.test import TestCase, Client, override_settings
+from django.contrib.auth.models import User
+
+from apps.tenants.models import Tenant, TenantMembership, SubscriptionPlan
+from apps.technician_portal.models import Technician
+
+TEST_OVERRIDES = {
+    'ALLOWED_HOSTS': ['*'],
+    'CACHES': {'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}},
+}
+
+
+def _make_plan(slug='trial'):
+    plan, _ = SubscriptionPlan.objects.get_or_create(
+        slug=slug,
+        defaults={
+            'name': slug.title(),
+            'monthly_price': Decimal('0.00'),
+            'trial_days': 30,
+            'display_order': 0,
+        },
+    )
+    return plan
+
+
+def _make_tenant_with_owner(name, slug):
+    plan = _make_plan()
+    user = User.objects.create_user(
+        slug, f'{slug}@test.com', 'testpass123',
+        first_name='Owner', last_name='User',
+    )
+    tenant = Tenant.objects.create(
+        name=name, slug=slug, subdomain=slug, owner=user,
+        subscription_plan=plan,
+    )
+    TenantMembership.objects.create(tenant=tenant, user=user, role='owner')
+    return user, tenant
+
+
+def _add_member(tenant, username, role, can_repair=True, can_replace=True):
+    """Create a user + TenantMembership + Technician record for the tenant."""
+    user = User.objects.create_user(
+        username, f'{username}@test.com', 'testpass123',
+        first_name='Test', last_name=username.title(),
+    )
+    TenantMembership.objects.create(tenant=tenant, user=user, role=role)
+    tech = Technician.objects.create(
+        user=user, tenant=tenant,
+        can_repair=can_repair,
+        can_replace=can_replace,
+        is_active=True,
+    )
+    return user, tech
+
+
+@override_settings(**TEST_OVERRIDES)
+class OwnerBadgesNotShownForOwnerRoleTest(TestCase):
+    """Owner-role members should NOT show ability badges (Repairs / Replacements)."""
+
+    def setUp(self):
+        self.owner_user, self.tenant = _make_tenant_with_owner('Badge Co', 'badgeco')
+        # Give the owner user a technician record with both abilities
+        self.owner_tech = Technician.objects.create(
+            user=self.owner_user, tenant=self.tenant,
+            can_repair=True, can_replace=True, is_active=True,
+        )
+        self.client = Client()
+        self.client.force_login(self.owner_user)
+
+    def test_settings_page_loads(self):
+        resp = self.client.get('/owner/settings/')
+        self.assertEqual(resp.status_code, 200)
+
+    def test_owner_role_badge_renders(self):
+        """The "Owner" role badge must still appear."""
+        resp = self.client.get('/owner/settings/')
+        self.assertContains(resp, 'Owner')
+
+    def test_ability_badges_not_shown_for_owner_role(self):
+        """When user has role=owner, the Repairs/Replacements badges must NOT render.
+
+        Because the page uses a Django template condition, we can't easily distinguish
+        which row the badge belongs to when there is only one member.  We verify by
+        ensuring the page does not contain the ability-badge markup that would only
+        appear for an owner (we add a second owner member and no tech-role members).
+        """
+        # Add a second owner-role member with can_repair
+        second_owner, _ = _add_member(self.tenant, 'owner2badge', 'owner', can_repair=True, can_replace=False)
+        resp = self.client.get('/owner/settings/')
+        content = resp.content.decode()
+        # The template guard `member.role != 'owner'` means no Repairs badge
+        # should appear since ALL members in this test are owners.
+        # "Repairs" text in the badge div has a specific class pair:
+        self.assertNotIn('bg-amber-100 text-amber-800', content)
+
+    def test_wrench_icon_used_not_tools(self):
+        """Repairs badge should use fa-wrench icon (not fa-tools)."""
+        # Add a technician-role member so the Repairs badge CAN render
+        _add_member(self.tenant, 'tech_wrench_test', 'technician', can_repair=True)
+        resp = self.client.get('/owner/settings/')
+        content = resp.content.decode()
+        self.assertIn('fa-wrench', content)
+        self.assertNotIn('fa-tools', content)
+
+
+@override_settings(**TEST_OVERRIDES)
+class TechnicianAbilityBadgesStillRenderTest(TestCase):
+    """Technician-role members SHOULD still show ability badges."""
+
+    def setUp(self):
+        self.owner_user, self.tenant = _make_tenant_with_owner('TechBadge Co', 'techbadgeco')
+        self.client = Client()
+        self.client.force_login(self.owner_user)
+
+    def test_repairs_badge_shown_for_technician_with_can_repair(self):
+        """Technician with can_repair=True must show the Repairs badge."""
+        _add_member(self.tenant, 'techrepair', 'technician', can_repair=True, can_replace=False)
+        resp = self.client.get('/owner/settings/')
+        self.assertContains(resp, 'Repairs')
+        self.assertContains(resp, 'bg-amber-100 text-amber-800')
+
+    def test_replacements_badge_shown_for_technician_with_can_replace(self):
+        """Technician with can_replace=True must show the Replacements badge."""
+        _add_member(self.tenant, 'techreplace', 'technician', can_repair=False, can_replace=True)
+        resp = self.client.get('/owner/settings/')
+        self.assertContains(resp, 'Replacements')
+        self.assertContains(resp, 'bg-teal-100 text-teal-800')
+
+    def test_no_ability_badges_when_technician_has_neither(self):
+        """Technician with both False must show neither badge."""
+        _add_member(self.tenant, 'techneither', 'technician', can_repair=False, can_replace=False)
+        resp = self.client.get('/owner/settings/')
+        # The amber and teal badge classes should not appear
+        self.assertNotIn('bg-amber-100 text-amber-800', resp.content.decode())
+        self.assertNotIn('bg-teal-100 text-teal-800', resp.content.decode())
+
+    def test_manager_role_shows_ability_badges(self):
+        """Manager-role member with can_repair should still show Repairs badge."""
+        _add_member(self.tenant, 'mgr_badges', 'manager', can_repair=True, can_replace=True)
+        resp = self.client.get('/owner/settings/')
+        self.assertContains(resp, 'Repairs')
+        self.assertContains(resp, 'Replacements')

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -402,3 +402,277 @@ class SubscriptionActionTests(TestCase):
         days_remaining = (self.tenant.grace_period_end - timezone.now()).days
         self.assertGreaterEqual(days_remaining, 29)
         self.assertTrue(self.tenant.is_in_grace_period)
+
+
+# =============================================================================
+# Phase 5: Tenant-Aware Filtering Tests
+# =============================================================================
+
+class TenantFilterMixinTests(TestCase):
+    """Tests for TenantFilterMixin — superuser vs. non-superuser queryset filtering."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from apps.tenants.models import Tenant, TenantMembership, SubscriptionPlan
+        from apps.technician_portal.models import Repair
+        from decimal import Decimal
+
+        # Two tenants
+        plan, _ = SubscriptionPlan.objects.get_or_create(
+            slug='trial-test', defaults={
+                'name': 'Trial Test', 'monthly_price': Decimal('0'), 'trial_days': 14
+            }
+        )
+
+        # Superuser can see everything
+        cls.superuser = User.objects.create_superuser(
+            username='super_filter', email='super@filter.com', password='Test1234!'
+        )
+        # Staff user belonging only to tenant A
+        cls.staff_a = User.objects.create_user(
+            username='staff_a_filter', email='staffa@filter.com',
+            password='Test1234!', is_staff=True, is_superuser=False
+        )
+        owner_b = User.objects.create_user(username='owner_b_filter', password='Test1234!')
+
+        # Grant view/change permissions for Repair and Customer
+        from django.contrib.auth.models import Permission
+        from django.contrib.contenttypes.models import ContentType
+        from apps.technician_portal.models import Repair as RepairModel
+        from core.models import Customer as CustomerModel
+        for model_cls in [RepairModel, CustomerModel]:
+            ct = ContentType.objects.get_for_model(model_cls)
+            for codename in [f'view_{ct.model}', f'change_{ct.model}']:
+                perm = Permission.objects.filter(content_type=ct, codename=codename).first()
+                if perm:
+                    cls.staff_a.user_permissions.add(perm)
+
+        cls.tenant_a = Tenant.objects.create(name='Tenant A', slug='tenant-a-filter', owner=cls.staff_a)
+        cls.tenant_b = Tenant.objects.create(name='Tenant B', slug='tenant-b-filter', owner=owner_b)
+        TenantMembership.objects.create(
+            tenant=cls.tenant_a, user=cls.staff_a, role='manager', is_active=True
+        )
+
+        # A customer per tenant
+        from core.models import Customer
+        cls.cust_a = Customer.objects.create(name='Customer A', tenant=cls.tenant_a)
+        cls.cust_b = Customer.objects.create(name='Customer B', tenant=cls.tenant_b)
+
+        # A technician per tenant
+        from apps.technician_portal.models import Technician
+        cls.tech_a = Technician.objects.create(user=cls.staff_a, tenant=cls.tenant_a, expertise='General')
+        cls.tech_b = Technician.objects.create(user=owner_b, tenant=cls.tenant_b, expertise='General')
+
+        # A repair per tenant
+        cls.repair_a = Repair.objects.create(
+            customer=cls.cust_a, tenant=cls.tenant_a, technician=cls.tech_a,
+            unit_number='UNIT-A', cost=Decimal('50'), queue_status='COMPLETED'
+        )
+        cls.repair_b = Repair.objects.create(
+            customer=cls.cust_b, tenant=cls.tenant_b, technician=cls.tech_b,
+            unit_number='UNIT-B', cost=Decimal('75'), queue_status='COMPLETED'
+        )
+
+    def setUp(self):
+        self.client = Client()
+
+    def _get_changelist_ids(self, url, user):
+        self.client.force_login(user)
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        return set(obj.pk for obj in resp.context['cl'].queryset)
+
+    def test_superuser_sees_all_repairs(self):
+        ids = self._get_changelist_ids(
+            reverse('admin:technician_portal_repair_changelist'), self.superuser
+        )
+        self.assertIn(self.repair_a.pk, ids)
+        self.assertIn(self.repair_b.pk, ids)
+
+    def test_non_superuser_sees_only_own_tenant_repairs(self):
+        ids = self._get_changelist_ids(
+            reverse('admin:technician_portal_repair_changelist'), self.staff_a
+        )
+        self.assertIn(self.repair_a.pk, ids)
+        self.assertNotIn(self.repair_b.pk, ids)
+
+    def test_superuser_sees_all_customers(self):
+        ids = self._get_changelist_ids(
+            reverse('admin:core_customer_changelist'), self.superuser
+        )
+        self.assertIn(self.cust_a.pk, ids)
+        self.assertIn(self.cust_b.pk, ids)
+
+    def test_non_superuser_sees_only_own_tenant_customers(self):
+        ids = self._get_changelist_ids(
+            reverse('admin:core_customer_changelist'), self.staff_a
+        )
+        self.assertIn(self.cust_a.pk, ids)
+        self.assertNotIn(self.cust_b.pk, ids)
+
+
+# =============================================================================
+# Phase 6a: Bulk Invoice Generation Tests
+# =============================================================================
+
+class BulkInvoiceGenerationTests(TestCase):
+    """Tests for the 'Generate draft invoices' admin action on CustomerAdmin."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from apps.tenants.models import Tenant, SubscriptionPlan
+        from apps.technician_portal.models import Repair
+        from decimal import Decimal
+
+        plan, _ = SubscriptionPlan.objects.get_or_create(
+            slug='trial-inv-test', defaults={
+                'name': 'Trial Inv Test', 'monthly_price': Decimal('0'), 'trial_days': 14
+            }
+        )
+        cls.admin_user = User.objects.create_superuser(
+            username='admin_inv', email='admin_inv@test.com', password='Test1234!'
+        )
+        cls.tenant = Tenant.objects.create(name='Invoice Tenant', slug='invoice-tenant', owner=cls.admin_user)
+
+        from core.models import Customer
+        from apps.technician_portal.models import Technician
+        cls.customer = Customer.objects.create(name='Inv Customer', tenant=cls.tenant)
+        cls.tech = Technician.objects.create(user=cls.admin_user, tenant=cls.tenant, expertise='General')
+
+        # Two completed repairs, no invoices
+        cls.repair1 = Repair.objects.create(
+            customer=cls.customer, tenant=cls.tenant, technician=cls.tech,
+            unit_number='T001', cost=Decimal('100'), queue_status='COMPLETED'
+        )
+        cls.repair2 = Repair.objects.create(
+            customer=cls.customer, tenant=cls.tenant, technician=cls.tech,
+            unit_number='T002', cost=Decimal('150'), queue_status='COMPLETED'
+        )
+        # One pending repair (should NOT be billed)
+        cls.repair_pending = Repair.objects.create(
+            customer=cls.customer, tenant=cls.tenant, technician=cls.tech,
+            unit_number='T003', cost=Decimal('50'), queue_status='PENDING'
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin_user)
+
+    def test_generate_invoices_creates_draft(self):
+        from apps.billing.models import Invoice, InvoiceLineItem
+        url = reverse('admin:core_customer_changelist')
+        data = {
+            'action': 'generate_invoices',
+            '_selected_action': [self.customer.pk],
+        }
+        resp = self.client.post(url, data, follow=True)
+        self.assertEqual(resp.status_code, 200)
+
+        invoice = Invoice.objects.filter(customer=self.customer, status='DRAFT').first()
+        self.assertIsNotNone(invoice)
+        self.assertEqual(invoice.line_items.count(), 2)
+
+        line_repairs = set(invoice.line_items.values_list('repair_id', flat=True))
+        self.assertIn(self.repair1.pk, line_repairs)
+        self.assertIn(self.repair2.pk, line_repairs)
+        self.assertNotIn(self.repair_pending.pk, line_repairs)
+
+    def test_generate_invoices_skips_already_billed(self):
+        """Running the action twice should not create duplicate line items."""
+        from apps.billing.models import Invoice, InvoiceLineItem
+        url = reverse('admin:core_customer_changelist')
+        data = {
+            'action': 'generate_invoices',
+            '_selected_action': [self.customer.pk],
+        }
+        self.client.post(url, data, follow=True)
+        self.client.post(url, data, follow=True)
+
+        # Should still be just one invoice (second run: no unbilled repairs left)
+        self.assertEqual(
+            Invoice.objects.filter(customer=self.customer, status='DRAFT').count(), 1
+        )
+
+
+# =============================================================================
+# Phase 6b: Audit Log Admin Tests
+# =============================================================================
+
+class AuditLogAdminTests(TestCase):
+    """Tests that the Django LogEntry admin view loads correctly."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='admin_audit', email='admin_audit@test.com', password='Test1234!'
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin_user)
+
+    def test_audit_log_changelist_loads(self):
+        url = reverse('admin:admin_logentry_changelist')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_audit_log_no_add_permission(self):
+        url = reverse('admin:admin_logentry_add')
+        resp = self.client.get(url)
+        # Should redirect or 403 (Django returns 403 for no add permission)
+        self.assertIn(resp.status_code, [302, 403])
+
+
+# =============================================================================
+# Phase 6c: Global Search Tests
+# =============================================================================
+
+class GlobalSearchTests(TestCase):
+    """Tests for the custom global admin search view."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from apps.tenants.models import Tenant
+        from decimal import Decimal
+
+        cls.admin_user = User.objects.create_superuser(
+            username='admin_search', email='admin_search@test.com', password='Test1234!'
+        )
+        cls.tenant = Tenant.objects.create(name='Search Tenant', slug='search-tenant', owner=cls.admin_user)
+
+        from core.models import Customer
+        cls.customer = Customer.objects.create(
+            name='Searchable Corp', email='search@corp.com', tenant=cls.tenant
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin_user)
+
+    def test_search_page_loads(self):
+        url = reverse('admin:global_search')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_search_returns_customer_results(self):
+        url = reverse('admin:global_search')
+        resp = self.client.get(url, {'q': 'Searchable'})
+        self.assertEqual(resp.status_code, 200)
+        customers = resp.context['results']['customers']
+        self.assertTrue(any(c.pk == self.customer.pk for c in customers))
+
+    def test_search_empty_query_no_results(self):
+        url = reverse('admin:global_search')
+        resp = self.client.get(url, {'q': ''})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context.get('results', {}), {})
+
+    def test_search_no_match_returns_empty(self):
+        url = reverse('admin:global_search')
+        resp = self.client.get(url, {'q': 'xyzzy_no_match_12345'})
+        self.assertEqual(resp.status_code, 200)
+        results = resp.context['results']
+        self.assertFalse(
+            any(list(v) for v in results.values()),
+            "Expected no results for a non-matching query"
+        )

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,404 @@
+"""
+Admin Console Tests — Phase 1 & 2 Verification
+
+Tests:
+- Admin pages load (200) for superuser
+- Custom dashboard renders
+- CSV export actions (Repair, Invoice, Customer)
+- Subscription management actions (extend trial, activate, deactivate)
+
+Run with:
+    python manage.py test tests.test_admin --settings=rs_systems.settings.development
+"""
+
+import csv
+import io
+from datetime import timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+
+
+class AdminPageLoadTests(TestCase):
+    """Verify all key admin changelist pages return 200 for superuser."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='test_admin',
+            email='admin@test.com',
+            password='Test1234!'
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin_user)
+
+    def _assert_page_ok(self, url_name, *args):
+        url = reverse(url_name, args=args) if args else reverse(url_name)
+        response = self.client.get(url)
+        self.assertEqual(
+            response.status_code, 200,
+            f"Expected 200 for {url_name}, got {response.status_code}"
+        )
+        return response
+
+    def test_admin_index_loads(self):
+        """Admin dashboard (index) should return 200."""
+        self._assert_page_ok('admin:index')
+
+    def test_tenant_changelist(self):
+        self._assert_page_ok('admin:tenants_tenant_changelist')
+
+    def test_tenant_add(self):
+        self._assert_page_ok('admin:tenants_tenant_add')
+
+    def test_subscription_plan_changelist(self):
+        self._assert_page_ok('admin:tenants_subscriptionplan_changelist')
+
+    def test_tenant_membership_changelist(self):
+        self._assert_page_ok('admin:tenants_tenantmembership_changelist')
+
+    def test_invoice_changelist(self):
+        self._assert_page_ok('admin:billing_invoice_changelist')
+
+    def test_payment_changelist(self):
+        self._assert_page_ok('admin:billing_payment_changelist')
+
+    def test_taxrate_changelist(self):
+        self._assert_page_ok('admin:billing_taxrate_changelist')
+
+    def test_repair_changelist(self):
+        self._assert_page_ok('admin:technician_portal_repair_changelist')
+
+    def test_customer_changelist(self):
+        self._assert_page_ok('admin:core_customer_changelist')
+
+    def test_technician_changelist(self):
+        self._assert_page_ok('admin:technician_portal_technician_changelist')
+
+    def test_customeruser_changelist(self):
+        self._assert_page_ok('admin:customer_portal_customeruser_changelist')
+
+    def test_customer_invitation_changelist(self):
+        self._assert_page_ok('admin:customer_portal_customerinvitation_changelist')
+
+    def test_user_changelist(self):
+        self._assert_page_ok('admin:auth_user_changelist')
+
+    def test_notification_changelist(self):
+        self._assert_page_ok('admin:core_notification_changelist')
+
+
+class AdminDashboardTests(TestCase):
+    """Custom dashboard metrics render correctly."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='dash_admin',
+            email='dash@test.com',
+            password='Test1234!'
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin_user)
+
+    def test_dashboard_loads(self):
+        response = self.client.get(reverse('admin:index'))
+        self.assertEqual(response.status_code, 200)
+        # Dashboard template should mention subscription-related content
+        content = response.content.decode()
+        self.assertIn('Subscription Overview', content)
+        self.assertIn('This Month', content)
+        self.assertIn('Recent Activity', content)
+        self.assertIn('Quick Links', content)
+
+    def test_dashboard_context_has_metrics(self):
+        response = self.client.get(reverse('admin:index'))
+        # Flatten the context (may be a ContextList with multiple levels)
+        if hasattr(response.context, 'flatten'):
+            ctx_flat = response.context.flatten()
+        else:
+            ctx_flat = {}
+            for c in response.context:
+                if hasattr(c, 'flatten'):
+                    ctx_flat.update(c.flatten())
+        # All metric keys should be present
+        metric_keys = [
+            'tenant_active_count', 'tenant_trial_count', 'tenant_grace_count',
+            'tenant_expired_count', 'tenant_total',
+            'repairs_this_month', 'invoices_this_month',
+            'revenue_this_month', 'outstanding_balance',
+        ]
+        for key in metric_keys:
+            self.assertIn(key, ctx_flat, f"Missing dashboard context key: {key}")
+
+    def test_dashboard_handles_empty_db(self):
+        """Dashboard should render cleanly with no data."""
+        response = self.client.get(reverse('admin:index'))
+        self.assertEqual(response.status_code, 200)
+        # Access keys via ContextList's string key lookup
+        self.assertEqual(response.context['tenant_total'], 0)
+        self.assertEqual(response.context['repairs_this_month'], 0)
+
+
+class RepairCSVExportTests(TestCase):
+    """Test CSV export action on RepairAdmin."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='repair_admin',
+            email='repair@test.com',
+            password='Test1234!'
+        )
+        # Create minimal data
+        from apps.tenants.models import Tenant
+        cls.tenant = Tenant.objects.create(
+            name='Export Test Shop',
+            slug='export-test-shop',
+            subdomain='export-test',
+            owner=cls.admin_user,
+        )
+        from core.models import Customer
+        cls.customer = Customer.objects.create(
+            name='Export Customer',
+            tenant=cls.tenant,
+        )
+        tech_user = User.objects.create_user(username='repair_tech', password='pass')
+        from apps.technician_portal.models import Technician, Repair
+        cls.technician = Technician.objects.create(user=tech_user)
+        cls.repair = Repair.objects.create(
+            tenant=cls.tenant,
+            customer=cls.customer,
+            technician=cls.technician,
+            unit_number='UNIT-001',
+            queue_status='COMPLETED',
+            cost=Decimal('50.00'),
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin_user)
+
+    def test_export_csv_returns_csv(self):
+        url = reverse('admin:technician_portal_repair_changelist')
+        data = {
+            'action': 'export_csv',
+            '_selected_action': [self.__class__.repair.pk],
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertIn('repairs.csv', response['Content-Disposition'])
+
+    def test_export_csv_content(self):
+        url = reverse('admin:technician_portal_repair_changelist')
+        data = {
+            'action': 'export_csv',
+            '_selected_action': [self.__class__.repair.pk],
+        }
+        response = self.client.post(url, data)
+        content = response.content.decode('utf-8')
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        self.assertEqual(rows[0][0], 'ID')
+        self.assertEqual(rows[0][2], 'Customer')
+        self.assertEqual(rows[1][2], 'Export Customer')
+        self.assertEqual(rows[1][3], 'UNIT-001')
+
+
+class InvoiceCSVExportTests(TestCase):
+    """Test CSV export action on InvoiceAdmin."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='invoice_admin',
+            email='invoice@test.com',
+            password='Test1234!'
+        )
+        from apps.tenants.models import Tenant
+        cls.tenant = Tenant.objects.create(
+            name='Invoice Test Shop',
+            slug='invoice-test-shop',
+            subdomain='invoice-test',
+            owner=cls.admin_user,
+        )
+        from core.models import Customer
+        cls.customer = Customer.objects.create(
+            name='Invoice Customer',
+            tenant=cls.tenant,
+        )
+        from apps.billing.models import Invoice
+        cls.invoice = Invoice.objects.create(
+            customer=cls.customer,
+            invoice_number='INV-0001',
+            invoice_date=timezone.now().date(),
+            due_date=timezone.now().date() + timedelta(days=30),
+            subtotal=Decimal('100.00'),
+            total=Decimal('100.00'),
+            status='SENT',
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin_user)
+
+    def test_export_csv_returns_csv(self):
+        url = reverse('admin:billing_invoice_changelist')
+        data = {
+            'action': 'export_csv',
+            '_selected_action': [self.invoice.pk],
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertIn('invoices.csv', response['Content-Disposition'])
+
+    def test_export_csv_content(self):
+        url = reverse('admin:billing_invoice_changelist')
+        data = {
+            'action': 'export_csv',
+            '_selected_action': [self.invoice.pk],
+        }
+        response = self.client.post(url, data)
+        content = response.content.decode('utf-8')
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        self.assertEqual(rows[0][0], 'Invoice #')
+        self.assertEqual(rows[1][0], 'INV-0001')
+        self.assertEqual(rows[1][1], 'Invoice Customer')
+
+
+class CustomerCSVExportTests(TestCase):
+    """Test CSV export action on CustomerAdmin."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='customer_admin',
+            email='cust_admin@test.com',
+            password='Test1234!'
+        )
+        from apps.tenants.models import Tenant
+        cls.tenant = Tenant.objects.create(
+            name='Customer Export Shop',
+            slug='customer-export-shop',
+            subdomain='customer-export',
+            owner=cls.admin_user,
+        )
+        from core.models import Customer
+        cls.customer = Customer.objects.create(
+            name='Exported Co',
+            tenant=cls.tenant,
+            email='exported@test.com',
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin_user)
+
+    def test_export_csv_returns_csv(self):
+        url = reverse('admin:core_customer_changelist')
+        data = {
+            'action': 'export_csv',
+            '_selected_action': [self.customer.pk],
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertIn('customers.csv', response['Content-Disposition'])
+
+    def test_export_csv_content(self):
+        url = reverse('admin:core_customer_changelist')
+        data = {
+            'action': 'export_csv',
+            '_selected_action': [self.customer.pk],
+        }
+        response = self.client.post(url, data)
+        content = response.content.decode('utf-8')
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        self.assertEqual(rows[0][0], 'ID')
+        self.assertEqual(rows[1][1], 'Exported Co')
+
+
+class SubscriptionActionTests(TestCase):
+    """Test subscription management admin actions on TenantAdmin."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='sub_admin',
+            email='sub@test.com',
+            password='Test1234!'
+        )
+        from apps.tenants.models import Tenant
+        cls.tenant = Tenant.objects.create(
+            name='Action Test Shop',
+            slug='action-test-shop',
+            subdomain='action-test',
+            owner=cls.admin_user,
+            plan='trial',
+            subscription_status='trialing',
+            trial_started_at=timezone.now(),
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin_user)
+        # Refresh from DB each test
+        self.tenant = type(self).tenant.__class__.objects.get(pk=type(self).tenant.pk)
+
+    def _post_action(self, action):
+        url = reverse('admin:tenants_tenant_changelist')
+        return self.client.post(url, {
+            'action': action,
+            '_selected_action': [self.tenant.pk],
+        })
+
+    def test_activate_subscription(self):
+        response = self._post_action('activate_subscription')
+        self.assertIn(response.status_code, [200, 302])
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.subscription_status, 'active')
+        self.assertTrue(self.tenant.is_active)
+
+    def test_deactivate_subscription(self):
+        self._post_action('deactivate_subscription')
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.subscription_status, 'expired')
+        self.assertIsNotNone(self.tenant.grace_period_end)
+        self.assertGreater(self.tenant.grace_period_end, timezone.now())
+
+    def test_extend_trial_7_days(self):
+        original_start = self.tenant.trial_started_at
+        self._post_action('extend_trial_7_days')
+        self.tenant.refresh_from_db()
+        expected = original_start + timedelta(days=7)
+        # Allow 1 second tolerance
+        diff = abs((self.tenant.trial_started_at - expected).total_seconds())
+        self.assertLess(diff, 2)
+
+    def test_extend_trial_30_days(self):
+        original_start = self.tenant.trial_started_at
+        self._post_action('extend_trial_30_days')
+        self.tenant.refresh_from_db()
+        expected = original_start + timedelta(days=30)
+        diff = abs((self.tenant.trial_started_at - expected).total_seconds())
+        self.assertLess(diff, 2)
+
+    def test_deactivate_sets_grace_period(self):
+        self._post_action('deactivate_subscription')
+        self.tenant.refresh_from_db()
+        # Grace period should be ~30 days from now
+        days_remaining = (self.tenant.grace_period_end - timezone.now()).days
+        self.assertGreaterEqual(days_remaining, 29)
+        self.assertTrue(self.tenant.is_in_grace_period)

--- a/tests/test_ux004_005_fixes.py
+++ b/tests/test_ux004_005_fixes.py
@@ -1,0 +1,189 @@
+"""
+Regression tests for UX-004 and UX-005:
+
+UX-004: Free Trial badge should use blue outline styling (not amber/orange)
+        to match the blue nav design system.
+
+UX-005: Onboarding step 2 tech creation should show clear, actionable
+        success messages including tech name and next steps.
+"""
+from django.test import TestCase
+from django.contrib.auth.models import User
+from apps.tenants.models import Tenant, TenantMembership, SubscriptionPlan
+from apps.tenants.services.signup_service import create_tenant_with_owner
+
+
+class TrialBadgeColorTests(TestCase):
+    """UX-004: Trial plan badge should use blue outline, not amber/orange."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.plan, _ = SubscriptionPlan.objects.get_or_create(
+            slug='trial',
+            defaults={'name': 'Free Trial', 'monthly_price': 0, 'trial_days': 30, 'is_active': True},
+        )
+
+    def setUp(self):
+        result = create_tenant_with_owner(
+            business_name='Trial Badge Shop', email='trialbadge@test.com',
+            password='testpass123!', first_name='Trial', last_name='Owner',
+        )
+        self.user = result['user']
+        self.tenant = result['tenant']
+        self.client.force_login(self.user)
+        session = self.client.session
+        session['tenant_id'] = self.tenant.id
+        session.save()
+
+    def test_trial_badge_has_blue_outline_classes(self):
+        """Trial plan badge should use blue outline (border-blue-300, text-blue-600, bg-white)."""
+        response = self.client.get('/owner/')
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        # Blue outline pill classes should be present
+        self.assertIn('border-blue-300', content)
+        self.assertIn('text-blue-600', content)
+        self.assertIn('bg-white', content)
+
+    def test_trial_badge_does_not_use_amber_classes(self):
+        """Trial plan badge should NOT use amber/orange classes (UX-004 fix)."""
+        response = self.client.get('/owner/')
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        # The nav badge section should not have amber-100/amber-800 for trial
+        # We check the plan badge specifically — amber colors should be gone from nav badge
+        self.assertNotIn('bg-amber-100 text-amber-800', content)
+
+    def test_trial_badge_shows_on_settings_page(self):
+        """Trial badge should be visible with blue styling on settings page."""
+        response = self.client.get('/owner/settings/')
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('border-blue-300', content)
+
+    def test_base_app_template_has_blue_trial_class_not_amber(self):
+        """The base_app.html template source should have blue classes, not amber, for trial plan."""
+        with open('templates/base_app.html', 'r') as f:
+            template_src = f.read()
+        # The trial plan conditional should use blue outline classes
+        self.assertIn('border-blue-300', template_src)
+        self.assertIn('text-blue-600', template_src)
+        # The amber class should not appear in the plan badge conditional
+        # (amber can appear elsewhere but not in the trial badge block)
+        trial_idx = template_src.find("tenant.plan == 'trial'")
+        # Get the surrounding context (next 100 chars)
+        badge_block = template_src[trial_idx:trial_idx+100]
+        self.assertNotIn('bg-amber-100', badge_block)
+
+    def test_trial_badge_shows_plan_display_text(self):
+        """Trial badge should still show the plan name text."""
+        response = self.client.get('/owner/')
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        # The plan display name should be shown (Free Trial or Trial)
+        self.assertIn('Trial', content)
+
+
+class OnboardingTechConfirmationTests(TestCase):
+    """UX-005: Onboarding step 2 tech creation shows clear, actionable messages."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.plan, _ = SubscriptionPlan.objects.get_or_create(
+            slug='trial',
+            defaults={'name': 'Free Trial', 'monthly_price': 0, 'trial_days': 30, 'is_active': True},
+        )
+
+    def setUp(self):
+        result = create_tenant_with_owner(
+            business_name='Onboarding Test Shop', email='onboardtest@test.com',
+            password='testpass123!', first_name='Onboard', last_name='Owner',
+        )
+        self.user = result['user']
+        self.tenant = result['tenant']
+        self.client.force_login(self.user)
+        session = self.client.session
+        session['tenant_id'] = self.tenant.id
+        session['onboarding_step'] = '2'
+        session.save()
+
+    def test_add_self_shows_clear_confirmation(self):
+        """Adding yourself as a tech should show a clear success message."""
+        response = self.client.post('/onboarding/?step=2', {
+            'add_self': True,
+            'tech_phone': '',
+            'tech_first_name': '',
+            'tech_last_name': '',
+            'tech_email': '',
+        }, follow=True)
+        self.assertEqual(response.status_code, 200)
+        messages_list = [str(m) for m in response.context['messages']]
+        # Should confirm the user was added
+        added_messages = [m for m in messages_list if 'technician' in m.lower()]
+        self.assertTrue(
+            len(added_messages) > 0,
+            f"Expected a technician confirmation message, got: {messages_list}"
+        )
+
+    def test_add_other_tech_with_email_shows_next_steps(self):
+        """Adding another person should show their name and point to Settings → Team for invite."""
+        response = self.client.post('/onboarding/?step=2', {
+            'add_self': False,
+            'tech_first_name': 'Alex',
+            'tech_last_name': 'Smith',
+            'tech_email': 'alex.smith.onboard@test.com',
+            'tech_phone': '555-0101',
+        }, follow=True)
+        self.assertEqual(response.status_code, 200)
+        messages_list = [str(m) for m in response.context['messages']]
+        # Should mention the tech's name or email
+        name_mentioned = any('Alex' in m or 'alex.smith' in m for m in messages_list)
+        self.assertTrue(name_mentioned, f"Tech name not in messages: {messages_list}")
+        # Should point to Settings → Team
+        settings_mentioned = any('Settings' in m for m in messages_list)
+        self.assertTrue(settings_mentioned, f"Settings guidance not in messages: {messages_list}")
+
+    def test_add_other_tech_without_email_mentions_invite(self):
+        """Adding a tech without email should still prompt user to add email for invite."""
+        response = self.client.post('/onboarding/?step=2', {
+            'add_self': False,
+            'tech_first_name': 'Jordan',
+            'tech_last_name': 'Lee',
+            'tech_email': '',
+            'tech_phone': '555-0202',
+        }, follow=True)
+        self.assertEqual(response.status_code, 200)
+        messages_list = [str(m) for m in response.context['messages']]
+        # Should encourage adding email for invite
+        invite_guidance = any(
+            'email' in m.lower() or 'invite' in m.lower() or 'settings' in m.lower()
+            for m in messages_list
+        )
+        self.assertTrue(invite_guidance, f"No invite guidance in messages: {messages_list}")
+
+    def test_no_tech_info_shows_helpful_message(self):
+        """Submitting step 2 with no tech info should show a helpful message with next steps."""
+        response = self.client.post('/onboarding/?step=2', {
+            'add_self': False,
+            'tech_first_name': '',
+            'tech_last_name': '',
+            'tech_email': '',
+            'tech_phone': '',
+        }, follow=True)
+        self.assertEqual(response.status_code, 200)
+        messages_list = [str(m) for m in response.context['messages']]
+        # Should mention Settings → Team as fallback
+        helpful = any('Settings' in m or 'later' in m for m in messages_list)
+        self.assertTrue(helpful, f"No helpful guidance in messages: {messages_list}")
+
+    def test_add_other_tech_advances_to_step_3(self):
+        """Successfully adding another tech should advance onboarding to step 3."""
+        response = self.client.post('/onboarding/?step=2', {
+            'add_self': False,
+            'tech_first_name': 'Sam',
+            'tech_last_name': 'Parker',
+            'tech_email': 'sam.parker.onboard@test.com',
+            'tech_phone': '',
+        }, follow=False)
+        # Should redirect to step 3
+        self.assertRedirects(response, '/onboarding/?step=3', fetch_redirect_response=False)


### PR DESCRIPTION
## UX-007 Fix — Customer detail missing phone/email affordance

### Problem
When an admin/owner viewed a customer with no phone or email, the contact card silently rendered nothing for those fields. There was no indication the fields existed or how to populate them.

### Fix
Added `{% elif can_edit_customer %}` blocks for both phone and email in `customer_details.html`:
- When phone is missing → show faded "Add phone number" link → edit page
- When email is missing → show faded "Add email address" link → edit page
- Regular technicians (non-editors) see no CTA — unchanged behavior
- "No contact information on file." fallback preserved for non-editor empty views

### Tests
11 regression tests in `tests/bug_fixes/test_ux007_customer_phone.py`:
- 6 template source checks (CTAs present, linked to edit URL, gated by `can_edit_customer`, fallback preserved)
- 5 HTTP-level view tests (phone displayed, email displayed, CTAs shown for owner, CTA NOT shown for regular tech)

All 11 pass ✅