### PR TITLE
Production hardening, admin forgot password, scaling docs, billing fixes

### DIFF
--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -11,6 +11,7 @@ Author: Amelia (Clawdbot AI)
 import json
 from datetime import datetime, timedelta
 from decimal import Decimal
+from django.db.models import Count
 from django.http import JsonResponse
 from django.views.decorators.http import require_GET, require_POST
 from django.views.decorators.csrf import csrf_exempt
@@ -128,7 +129,12 @@ def list_invoices(request):
     if request.GET.get('outstanding', '').lower() == 'true':
         invoices = invoices.filter(status__in=['SENT', 'PARTIAL', 'OVERDUE'])
 
-    invoices = invoices.select_related('customer').order_by('-invoice_date')[:50]
+    invoices = (
+        invoices
+        .select_related('customer')
+        .annotate(line_item_count=Count('line_items'))
+        .order_by('-invoice_date')[:50]
+    )
 
     return JsonResponse({
         'invoices': [{
@@ -142,7 +148,7 @@ def list_invoices(request):
             'amount_due': float(inv.amount_due),
             'status': inv.status,
             'stripe_hosted_url': inv.stripe_hosted_url or None,
-            'line_item_count': inv.line_items.count(),
+            'line_item_count': inv.line_item_count,
         } for inv in invoices],
         'count': len(invoices),
     })
@@ -379,25 +385,35 @@ def send_invoice_email_batch(request):
     from apps.billing.services.invoice_email_service import InvoiceEmailService
     email_svc = InvoiceEmailService(tenant=tenant)
 
+    # Fetch all requested invoices in one query (with customer & line items prefetched)
+    # to avoid N individual .get() calls + lazy FK traversals inside the loop.
+    invoice_map = {
+        inv.id: inv
+        for inv in Invoice.objects.filter(
+            id__in=invoice_ids, tenant=tenant
+        ).select_related('customer').prefetch_related('line_items')
+    }
+
     results = []
     for inv_id in invoice_ids:
+        invoice = invoice_map.get(inv_id)
+        if invoice is None:
+            results.append({'id': inv_id, 'success': False, 'error': 'Not found'})
+            continue
         try:
-            invoice = Invoice.objects.get(id=inv_id, tenant=tenant)
             if invoice.status == 'PAID':
                 results.append({'id': inv_id, 'success': False, 'error': 'Already paid'})
                 continue
             if not invoice.customer.email:
                 results.append({'id': inv_id, 'success': False, 'error': 'No email'})
                 continue
-            repair_ids = list(invoice.line_items.values_list('repair_id', flat=True))
+            repair_ids = [item.repair_id for item in invoice.line_items.all()]
             email_svc.send_invoice_email(
                 customer_id=invoice.customer_id,
                 recipient_email=invoice.customer.email,
                 repair_ids=repair_ids if repair_ids else None,
             )
             results.append({'id': inv_id, 'success': True, 'sent_to': invoice.customer.email})
-        except Invoice.DoesNotExist:
-            results.append({'id': inv_id, 'success': False, 'error': 'Not found'})
         except Exception as e:
             results.append({'id': inv_id, 'success': False, 'error': str(e)})
 

--- a/apps/technician_portal/admin.py
+++ b/apps/technician_portal/admin.py
@@ -320,11 +320,21 @@ class CustomerAdmin(TenantFilterMixin, admin.ModelAdmin):
         skipped = 0
 
         for customer in queryset.select_related('tenant'):
-            # Find completed repairs not yet linked to any invoice line item
+            # Find completed repairs not yet on any active (non-cancelled) invoice.
+            # We intentionally do NOT exclude repairs linked to CANCELLED invoices —
+            # those repairs should be re-invoiceable.
+            # We also skip repairs flagged as skip_invoicing (already accounted for
+            # outside the normal billing flow).
+            invoiced_repair_ids = InvoiceLineItem.objects.filter(
+                repair__isnull=False,
+                invoice__tenant=customer.tenant,
+                invoice__status__in=['DRAFT', 'SENT', 'PARTIAL', 'PAID'],
+            ).values_list('repair_id', flat=True)
+
             unbilled_repairs = (
                 Repair.objects
-                .filter(customer=customer, queue_status='COMPLETED')
-                .exclude(invoice_line_items__isnull=False)
+                .filter(customer=customer, queue_status='COMPLETED', skip_invoicing=False)
+                .exclude(id__in=invoiced_repair_ids)
                 .order_by('service_date')
             )
 

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -1,0 +1,181 @@
+# RS Systems — Scaling Guide
+
+*Last updated: 2026-03-15*
+
+This document covers the current infrastructure, known scaling thresholds, and the upgrade path for each component as traffic grows.
+
+---
+
+## Current Architecture
+
+```
+User → CloudFlare → ALB → Elastic Beanstalk (single instance)
+                                  │
+                                  ├── Gunicorn (Django 5.1)
+                                  ├── PostgreSQL (RDS)
+                                  ├── S3 (media/photos)
+                                  └── DatabaseCache (ratelimit, throttling)
+```
+
+**No Redis. No Celery. No background workers.**
+Notifications are synchronous. Billing tasks run via management commands + EB cron.
+
+---
+
+## Component Scaling Thresholds
+
+### 1. Caching — DatabaseCache → Redis
+
+**Current:** `django.core.cache.backends.db.DatabaseCache`
+Every cache read/write is a SQL query against the `django_cache` table in RDS.
+
+| Traffic | Impact | Action |
+|---------|--------|--------|
+| < 50 concurrent users | Negligible | None needed |
+| 50–200 concurrent users | ~5-10% DB load increase | Monitor RDS CPU |
+| 200+ concurrent users | Cache queries compete with app queries | **Upgrade to Redis** |
+
+**Upgrade path:**
+1. Create ElastiCache Redis instance (cache.t3.micro, ~$15/mo)
+2. Set `REDIS_URL` in EB environment variables
+3. Deploy — code auto-detects and switches to `RedisCache` (zero code changes)
+
+**What uses the cache:**
+- `django-ratelimit` (login, registration)
+- DRF throttling (API rate limits)
+- Future: template fragment caching, session storage
+
+---
+
+### 2. Web Server — Single Instance → Auto Scaling Group
+
+**Current:** Single EB instance running Gunicorn
+
+| Traffic | Impact | Action |
+|---------|--------|--------|
+| < 100 req/sec | Fine | None needed |
+| 100–500 req/sec | Response times increase | **Add auto scaling** |
+| 500+ req/sec | Possible timeouts | Auto scaling + CDN for static |
+
+**Upgrade path:**
+1. EB console → Configuration → Capacity → change to "Load balanced" (if not already)
+2. Set min=1, max=3 instances
+3. Configure scaling triggers (CPU > 70%, latency > 2s)
+4. Ensure sessions use DB backend (already do) — sticky sessions not needed
+
+**Important:** `LocMemCache` would break with multiple instances (each worker has its own cache). `DatabaseCache` and `RedisCache` both work across instances. This is why we chose DatabaseCache over LocMemCache.
+
+---
+
+### 3. Database — RDS Scaling
+
+**Current:** RDS PostgreSQL (instance size set in AWS console)
+
+| Metric | Warning | Critical |
+|--------|---------|----------|
+| CPU utilization | > 60% sustained | > 80% sustained |
+| Free storage | < 5 GB | < 1 GB |
+| Connection count | > 80% of max | > 95% of max |
+| Read latency | > 10ms avg | > 50ms avg |
+
+**Upgrade path (in order):**
+1. **Read replicas** — offload reporting/analytics queries
+2. **Instance size** — scale vertically (db.t3.medium → db.t3.large)
+3. **Connection pooling** — PgBouncer or RDS Proxy (~$15/mo)
+4. **Query optimization** — N+1 fixes, index tuning (ongoing)
+
+---
+
+### 4. Background Tasks — Synchronous → Task Queue
+
+**Current:** Email notifications are synchronous (sent during request). Billing tasks run via management commands on EB cron.
+
+| Symptom | Trigger | Action |
+|---------|---------|--------|
+| Slow page loads after actions that send email | > 50 emails/day | **Add task queue** |
+| Batch invoice generation timing out | > 500 invoices/batch | **Add task queue** |
+| Webhook processing blocking responses | > 100 webhooks/hour | **Add task queue** |
+
+**Upgrade path:**
+1. Add Redis (needed anyway for cache at this point)
+2. Re-enable Celery with Redis as broker
+3. Move email, webhook processing, and batch jobs to async tasks
+4. Run Celery worker as a separate EB worker environment or ECS task
+
+---
+
+### 5. Media/Photos — S3 (Already Scaled)
+
+**Current:** S3 with direct URLs. No CDN.
+
+| Traffic | Impact | Action |
+|---------|--------|--------|
+| < 1000 photos/day | Fine | None needed |
+| 1000+ photos/day served | S3 egress costs increase | **Add CloudFront CDN** |
+
+**Upgrade path:**
+1. Create CloudFront distribution pointing to S3 bucket
+2. Update `AWS_S3_CUSTOM_DOMAIN` to CloudFront domain
+3. ~$0.085/GB egress vs $0.09/GB direct from S3
+
+---
+
+### 6. Stripe — Single Account → Connect Platform
+
+**Current:** All payments flow to a single Stripe account. No multi-tenant payment routing.
+
+| Milestone | Action |
+|-----------|--------|
+| First external shop signs up | **Implement Stripe Connect** |
+| External shops need to receive customer payments | Required — see `docs/proposals/stripe-connect-multi-tenant-payments.md` |
+
+---
+
+## Scaling Decision Checklist
+
+When you notice performance issues, check in this order:
+
+1. **Is RDS CPU > 60%?** → Check for N+1 queries, missing indexes, or scale instance
+2. **Are response times > 2s?** → Check if it's DB, email sending, or Stripe API calls
+3. **Is the cache table growing large?** → Consider Redis upgrade
+4. **Are you running multiple EB instances?** → Ensure DatabaseCache or Redis (not LocMemCache)
+5. **Are emails slowing down requests?** → Time to add Celery
+
+---
+
+## Environment Variables for Scaling
+
+These env vars control scaling behavior with zero code changes:
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `REDIS_URL` | *(not set)* | Set to switch cache from DatabaseCache → Redis |
+| `REDIS_CACHE_URL` | *(not set)* | Override cache-specific Redis URL (if different from broker) |
+| `USE_S3` | `False` | Set `True` to store media in S3 instead of local filesystem |
+| `SENTRY_DSN` | *(not set)* | Set to enable error tracking (recommended) |
+| `AWS_CLOUDWATCH_ENABLED` | `False` | Set `True` to enable CloudWatch metrics |
+
+---
+
+## Cost Estimates at Scale
+
+| Component | Current Cost | At 100 shops | At 500 shops |
+|-----------|-------------|-------------|-------------|
+| EB (single instance) | ~$15/mo | ~$30/mo (2 instances) | ~$60/mo (3-4 instances) |
+| RDS PostgreSQL | ~$15/mo | ~$30/mo (larger instance) | ~$60/mo + read replica |
+| ElastiCache Redis | $0 | ~$15/mo | ~$15/mo |
+| S3 + CloudFront | ~$1/mo | ~$5/mo | ~$15/mo |
+| Celery workers | $0 | ~$15/mo (1 worker) | ~$30/mo (2 workers) |
+| **Total** | **~$31/mo** | **~$95/mo** | **~$180/mo** |
+
+These are rough estimates. Actual costs depend on usage patterns (photos per repair, invoice volume, API calls).
+
+---
+
+## What NOT to Do
+
+- **Don't add Redis "just in case"** — it's another service to monitor and pay for. Add it when DatabaseCache shows strain.
+- **Don't switch to LocMemCache** — it's per-process, breaks with multiple gunicorn workers or EB instances.
+- **Don't add Celery without Redis** — Celery needs a broker. If you need Celery, you need Redis (or SQS).
+- **Don't enable auto-scaling without testing** — verify sessions, cache, and file uploads work across instances first.
+- **Don't optimize prematurely** — profile first, then fix the actual bottleneck.

--- a/rs_systems/urls.py
+++ b/rs_systems/urls.py
@@ -50,6 +50,12 @@ urlpatterns = [
     path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 
     # Admin and authentication
+    path('admin/password_reset/', auth_views.PasswordResetView.as_view(
+        template_name='registration/password_reset_form.html',
+        email_template_name='registration/password_reset_email.html',
+        subject_template_name='registration/password_reset_subject.txt',
+        success_url='/password-reset/done/',
+    ), name='admin_password_reset'),
     path('admin/register-technician/', views.register_technician, name='register_technician'),
     path('admin/email-preview/<str:template_name>/', preview_email_template, name='email_preview'),
     path('admin/', admin.site.urls),

--- a/tests/bug_fixes/test_code037_admin_generate_invoices_cancelled.py
+++ b/tests/bug_fixes/test_code037_admin_generate_invoices_cancelled.py
@@ -1,0 +1,264 @@
+"""
+CODE-037 Regression: Admin generate_invoices action ignores CANCELLED invoices
+and skip_invoicing flag.
+
+Bug 1 (Cancelled invoice blocks re-billing):
+  generate_invoices() used:
+      .exclude(invoice_line_items__isnull=False)
+  This excluded repairs linked to ANY invoice line item — including line items
+  on CANCELLED invoices.  A shop that cancels an invoice can NEVER re-invoice
+  those repairs via the admin action.
+
+Bug 2 (skip_invoicing flag ignored):
+  The action did not filter out repairs with skip_invoicing=True.
+  Repairs explicitly flagged as "already accounted for" got included in
+  admin-generated draft invoices, causing double-billing.
+
+Fix:
+  - Replaced bare `.exclude(invoice_line_items__isnull=False)` with a scoped
+    subquery that only excludes repairs on DRAFT/SENT/PARTIAL/PAID invoices
+    (same pattern as InvoiceTrackingService.get_uninvoiced_repairs).
+  - Added `.filter(skip_invoicing=False)` to the queryset.
+
+Tests:
+  1. Repair on an active DRAFT invoice → excluded (correct, no double-billing)
+  2. Repair on a CANCELLED invoice → NOT excluded (re-invoiceable)
+  3. Repair with skip_invoicing=True → excluded (respect the flag)
+  4. Repair with skip_invoicing=False and no invoice → included (normal flow)
+  5. Cross-tenant scoping: invoiced_repair_ids only considers the customer's tenant
+  6. Multiple repairs, some active-invoiced, some cancelled: only active-invoiced ones skipped
+"""
+
+import uuid
+from decimal import Decimal
+from django.test import TestCase, RequestFactory
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from apps.tenants.models import Tenant
+from apps.billing.models import Invoice, InvoiceLineItem
+from apps.technician_portal.models import Repair, Technician
+from apps.technician_portal.admin import CustomerAdmin
+from core.models import Customer
+
+
+def _make_tenant(slug):
+    uid = uuid.uuid4().hex[:4]
+    owner = User.objects.create_user(
+        username=f'own{slug}{uid}',
+        email=f'own{slug}{uid}@test.com',
+        password='pass',
+    )
+    return Tenant.objects.create(
+        name=f'T-{slug}-{uid}',
+        slug=f'{slug}{uid}',
+        subdomain=f'{slug}{uid}',
+        plan='trial',
+        trial_started_at=timezone.now(),
+        owner=owner,
+        is_active=True,
+    )
+
+
+def _make_customer(tenant, name='Fleet Co'):
+    return Customer.objects.create(
+        tenant=tenant,
+        name=name,
+        email=f'{uuid.uuid4().hex[:8]}@fleet.com',
+    )
+
+
+def _make_technician(tenant):
+    user = User.objects.create_user(
+        username=f'tech_{uuid.uuid4().hex[:6]}',
+        password='pass',
+    )
+    return Technician.objects.create(
+        user=user,
+        tenant=tenant,
+        is_active=True,
+    )
+
+
+def _make_repair(customer, tenant, technician, cost=Decimal('45.00'), skip_invoicing=False, unit_number='101'):
+    """
+    Create a completed repair with an explicit cost.
+    We use cost_override so Repair.save() doesn't recalculate the cost via
+    the pricing service (which would ignore our test value).
+    """
+    repair = Repair.objects.create(
+        customer=customer,
+        tenant=tenant,
+        technician=technician,
+        unit_number=unit_number,
+        queue_status='COMPLETED',
+        service_date=timezone.now().date(),
+        cost_override=cost,
+        skip_invoicing=skip_invoicing,
+    )
+    # Reload to get the cost field as saved by Repair.save()
+    repair.refresh_from_db()
+    return repair
+
+
+def _make_invoice(tenant, customer, status='DRAFT'):
+    return Invoice.objects.create(
+        tenant=tenant,
+        customer=customer,
+        invoice_number=f'INV-{uuid.uuid4().hex[:8]}',
+        status=status,
+        invoice_date=timezone.now().date(),
+        subtotal=Decimal('45.00'),
+        discount=Decimal('0.00'),
+        tax_rate=Decimal('0.00'),
+        tax_amount=Decimal('0.00'),
+        total=Decimal('45.00'),
+        amount_paid=Decimal('0.00'),
+        payment_terms='NET30',
+    )
+
+
+def _attach_repair_to_invoice(invoice, repair):
+    return InvoiceLineItem.objects.create(
+        invoice=invoice,
+        repair=repair,
+        description='Repair',
+        quantity=1,
+        unit_price=repair.cost,
+        discount=Decimal('0.00'),
+        amount=repair.cost,
+        repair_date=repair.service_date,
+        unit_number=repair.unit_number or '',
+    )
+
+
+class AdminGenerateInvoicesCancelledTest(TestCase):
+    """Tests for the generate_invoices admin action's repair scoping logic."""
+
+    def setUp(self):
+        self.tenant = _make_tenant('main')
+        self.customer = _make_customer(self.tenant)
+        self.technician = _make_technician(self.tenant)
+
+        # Admin user for requests
+        self.admin_user = User.objects.create_superuser(
+            username='superadmin', email='admin@test.com', password='pass'
+        )
+        self.site = AdminSite()
+        self.admin = CustomerAdmin(Customer, self.site)
+        self.factory = RequestFactory()
+
+    def _run_action(self, customers):
+        """Invoke generate_invoices on a queryset of customers."""
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        request = self.factory.post('/')
+        request.user = self.admin_user
+        # Admin's message_user() requires messages middleware; set up in-memory storage.
+        setattr(request, 'session', 'session')
+        messages_storage = FallbackStorage(request)
+        setattr(request, '_messages', messages_storage)
+        qs = Customer.objects.filter(id__in=[c.id for c in customers])
+        self.admin.generate_invoices(request, qs)
+
+    def test_repair_on_draft_invoice_is_excluded(self):
+        """A repair already on a DRAFT invoice must NOT be re-invoiced."""
+        repair = _make_repair(self.customer, self.tenant, self.technician)
+        invoice = _make_invoice(self.tenant, self.customer, status='DRAFT')
+        _attach_repair_to_invoice(invoice, repair)
+
+        initial_count = Invoice.objects.filter(tenant=self.tenant).count()
+        self._run_action([self.customer])
+        final_count = Invoice.objects.filter(tenant=self.tenant).count()
+
+        self.assertEqual(initial_count, final_count, "No new invoice should be created — repair is already on a DRAFT invoice")
+
+    def test_repair_on_cancelled_invoice_is_included(self):
+        """A repair on a CANCELLED invoice MUST be re-invoiceable."""
+        repair = _make_repair(self.customer, self.tenant, self.technician)
+        cancelled_invoice = _make_invoice(self.tenant, self.customer, status='CANCELLED')
+        _attach_repair_to_invoice(cancelled_invoice, repair)
+
+        initial_count = Invoice.objects.filter(tenant=self.tenant).count()
+        self._run_action([self.customer])
+        final_count = Invoice.objects.filter(tenant=self.tenant).count()
+
+        self.assertEqual(final_count, initial_count + 1, "A new draft invoice should be created for the repair on the cancelled invoice")
+
+        new_invoice = Invoice.objects.filter(tenant=self.tenant).exclude(id=cancelled_invoice.id).latest('id')
+        self.assertEqual(new_invoice.status, 'DRAFT')
+        self.assertEqual(new_invoice.line_items.filter(repair=repair).count(), 1)
+
+    def test_skip_invoicing_repair_is_excluded(self):
+        """Repairs with skip_invoicing=True must not appear in admin-generated invoices."""
+        _make_repair(self.customer, self.tenant, self.technician, skip_invoicing=True)
+
+        initial_count = Invoice.objects.filter(tenant=self.tenant).count()
+        self._run_action([self.customer])
+        final_count = Invoice.objects.filter(tenant=self.tenant).count()
+
+        self.assertEqual(initial_count, final_count, "skip_invoicing=True repairs must be excluded from admin-generated invoices")
+
+    def test_normal_uninvoiced_repair_is_included(self):
+        """A completed repair with no invoice and skip_invoicing=False must be invoiced."""
+        repair = _make_repair(self.customer, self.tenant, self.technician, skip_invoicing=False)
+
+        initial_count = Invoice.objects.filter(tenant=self.tenant).count()
+        self._run_action([self.customer])
+        final_count = Invoice.objects.filter(tenant=self.tenant).count()
+
+        self.assertEqual(final_count, initial_count + 1, "A draft invoice should be created for the uninvoiced repair")
+
+        new_invoice = Invoice.objects.filter(tenant=self.tenant).latest('id')
+        self.assertEqual(new_invoice.status, 'DRAFT')
+        self.assertEqual(new_invoice.line_items.filter(repair=repair).count(), 1)
+
+    def test_cross_tenant_invoice_does_not_block_own_tenant(self):
+        """An invoice from another tenant must not suppress this tenant's repair."""
+        other_tenant = _make_tenant('other')
+        other_customer = _make_customer(other_tenant, 'Other Fleet')
+        other_tech = _make_technician(other_tenant)
+
+        # Same repair PK is impossible to share — but we create a repair in our tenant
+        # that is NOT on any invoice of its own, while another tenant has a repair on an invoice.
+        # The key test is that our invoiced_repair_ids subquery is scoped to customer.tenant.
+        repair = _make_repair(self.customer, self.tenant, self.technician)
+
+        other_repair = _make_repair(other_customer, other_tenant, other_tech)
+        other_invoice = _make_invoice(other_tenant, other_customer, status='DRAFT')
+        _attach_repair_to_invoice(other_invoice, other_repair)
+
+        initial_count = Invoice.objects.filter(tenant=self.tenant).count()
+        self._run_action([self.customer])
+        final_count = Invoice.objects.filter(tenant=self.tenant).count()
+
+        self.assertEqual(final_count, initial_count + 1, "Our tenant's repair should be invoiced regardless of other tenants")
+
+    def test_mixed_repairs_only_unbilled_get_invoiced(self):
+        """When a customer has both active-invoiced and cancelled-invoiced repairs,
+        only the one on the cancelled invoice should appear in the new draft."""
+        active_repair = _make_repair(self.customer, self.tenant, self.technician, cost=Decimal('50.00'), unit_number='A01')
+        cancelled_repair = _make_repair(self.customer, self.tenant, self.technician, cost=Decimal('75.00'), unit_number='B02')
+
+        active_invoice = _make_invoice(self.tenant, self.customer, status='SENT')
+        _attach_repair_to_invoice(active_invoice, active_repair)
+
+        cancelled_invoice = _make_invoice(self.tenant, self.customer, status='CANCELLED')
+        _attach_repair_to_invoice(cancelled_invoice, cancelled_repair)
+
+        self._run_action([self.customer])
+
+        # One new draft invoice should have been created
+        new_invoices = Invoice.objects.filter(
+            tenant=self.tenant,
+            status='DRAFT',
+        ).exclude(id=active_invoice.id).exclude(id=cancelled_invoice.id)
+        self.assertEqual(new_invoices.count(), 1)
+
+        new_invoice = new_invoices.first()
+        # Only the cancelled_repair should be in it
+        self.assertEqual(new_invoice.line_items.filter(repair=cancelled_repair).count(), 1)
+        self.assertEqual(new_invoice.line_items.filter(repair=active_repair).count(), 0)
+        # Total should reflect only the cancelled_repair's actual cost (set by pricing service)
+        cancelled_repair.refresh_from_db()
+        self.assertEqual(new_invoice.total, cancelled_repair.cost)

--- a/tests/bug_fixes/test_code038_billing_views_n_plus_one.py
+++ b/tests/bug_fixes/test_code038_billing_views_n_plus_one.py
@@ -1,0 +1,306 @@
+"""
+CODE-038 Regression: N+1 queries in billing API views.
+
+Bug 1 (list_invoices):
+  The serialization loop called `inv.line_items.count()` per-invoice — one
+  extra DB round-trip per invoice on every list request.  For 50 invoices
+  that's 50 extra COUNT queries.
+
+  Fix: `.annotate(line_item_count=Count('line_items'))` on the queryset so
+  Django computes the count in the initial SELECT (zero extra queries).
+
+Bug 2 (send_invoice_email_batch):
+  The batch loop called `Invoice.objects.get(id=inv_id, tenant=tenant)`
+  once per invoice ID, then accessed `invoice.customer.email` via a lazy FK
+  load — producing 2×N DB round-trips (N SELECTs for invoices + N SELECTs
+  for customers).  For 10 invoices: 20 extra queries.
+
+  Fix: prefetch all invoices with `select_related('customer')` and
+  `prefetch_related('line_items')` in a single queryset before the loop.
+
+Tests:
+  1. list_invoices: annotated line_item_count is correct (matches actual count)
+  2. list_invoices: zero additional queries after annotate (no per-row COUNT)
+  3. list_invoices: tenant isolation — only this tenant's invoices returned
+  4. list_invoices: customer_id filter works with annotation present
+  5. send_invoice_email_batch: all found invoices returned as success/skip
+  6. send_invoice_email_batch: unknown invoice IDs return 'Not found' entry
+  7. send_invoice_email_batch: query count is bounded (2 queries regardless of N)
+  8. send_invoice_email_batch: cross-tenant invoice IDs are treated as 'Not found'
+"""
+
+import uuid
+from decimal import Decimal
+from unittest.mock import patch, MagicMock
+
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import User
+from django.utils import timezone
+from django.test.utils import CaptureQueriesContext
+from django.db import connection
+
+from apps.tenants.models import Tenant, SubscriptionPlan, TenantMembership
+from apps.billing.models import Invoice, InvoiceLineItem, BillingConfig
+from apps.technician_portal.models import Repair, Technician
+from core.models import Customer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tenant(slug):
+    plan, _ = SubscriptionPlan.objects.get_or_create(
+        name='Test Plan',
+        defaults={
+            'stripe_price_id': 'price_test',
+            'monthly_price': Decimal('0.00'),
+            'annual_price': Decimal('0.00'),
+            'max_technicians': 10,
+            'max_repairs_per_month': 200,
+        },
+    )
+    owner = User.objects.create_user(
+        username=f'owner_{slug}', password='pass', email=f'owner@{slug}.com'
+    )
+    tenant = Tenant.objects.create(
+        name=f'Shop {slug}',
+        slug=slug,
+        owner=owner,
+        subscription_plan=plan,
+    )
+    TenantMembership.objects.get_or_create(
+        user=owner, tenant=tenant,
+        defaults={'role': 'owner', 'is_active': True},
+    )
+    BillingConfig.objects.get_or_create(tenant=tenant)
+    return tenant, owner
+
+
+def _make_customer(tenant, name='Test Fleet', email='fleet@example.com'):
+    return Customer.objects.create(
+        tenant=tenant,
+        name=name,
+        email=email,
+    )
+
+
+def _make_invoice(tenant, customer, n_line_items=2, status='DRAFT'):
+    inv = Invoice.objects.create(
+        tenant=tenant,
+        customer=customer,
+        invoice_number=f'INV-{uuid.uuid4().hex[:8].upper()}',
+        invoice_date=timezone.now().date(),
+        status=status,
+        subtotal=Decimal('100.00'),
+        total=Decimal('100.00'),
+        amount_paid=Decimal('0.00'),
+        # amount_due is a @property (total - amount_paid), not a DB field
+    )
+    for i in range(n_line_items):
+        InvoiceLineItem.objects.create(
+            invoice=inv,
+            description=f'Line item {i}',
+            quantity=1,
+            unit_price=Decimal('50.00'),
+            amount=Decimal('50.00'),
+        )
+    return inv
+
+
+def _authed_request(factory, user, tenant, path='/'):
+    request = factory.get(path)
+    request.user = user
+    request.tenant = tenant
+    return request
+
+
+# ---------------------------------------------------------------------------
+# Tests: list_invoices
+# ---------------------------------------------------------------------------
+
+class ListInvoicesAnnotationTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.tenant, self.owner = _make_tenant('billing-list')
+        self.customer = _make_customer(self.tenant)
+
+    def _get(self, params=''):
+        from apps.billing.views import list_invoices
+        req = self.factory.get(f'/api/billing/invoices/{params}')
+        req.user = self.owner
+        req.tenant = self.tenant
+        return list_invoices(req)
+
+    def test_line_item_count_correct(self):
+        """Annotated line_item_count matches actual number of line items."""
+        _make_invoice(self.tenant, self.customer, n_line_items=3)
+        _make_invoice(self.tenant, self.customer, n_line_items=1)
+
+        resp = self._get()
+        self.assertEqual(resp.status_code, 200)
+        import json
+        data = json.loads(resp.content)
+        counts = sorted(i['line_item_count'] for i in data['invoices'])
+        self.assertEqual(counts, [1, 3])
+
+    def test_no_extra_count_queries(self):
+        """Serialization loop should NOT fire extra COUNT queries per invoice."""
+        for _ in range(5):
+            _make_invoice(self.tenant, self.customer, n_line_items=2)
+
+        from apps.billing.views import list_invoices
+        req = self.factory.get('/api/billing/invoices/')
+        req.user = self.owner
+        req.tenant = self.tenant
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = list_invoices(req)
+        self.assertEqual(resp.status_code, 200)
+
+        # All queries combined: 1 annotated SELECT (invoices + count join)
+        # There must be NO separate COUNT(*) queries for individual invoices.
+        count_queries = [
+            q for q in ctx.captured_queries
+            if 'COUNT' in q['sql'].upper()
+            and 'line_items' in q['sql'].lower()
+            and 'GROUP BY' not in q['sql'].upper()
+            # GROUP BY = the annotate aggregation (good); bare COUNT = the old per-row (bad)
+        ]
+        self.assertEqual(
+            len(count_queries), 0,
+            f"Found {len(count_queries)} per-row COUNT queries: {count_queries}"
+        )
+
+    def test_tenant_isolation(self):
+        """list_invoices only returns invoices for the request tenant."""
+        tenant2, owner2 = _make_tenant('billing-list-other')
+        customer2 = _make_customer(tenant2, name='Other Fleet', email='other@fleet.com')
+
+        _make_invoice(self.tenant, self.customer, n_line_items=1)
+        _make_invoice(tenant2, customer2, n_line_items=1)
+
+        resp = self._get()
+        import json
+        data = json.loads(resp.content)
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(data['invoices'][0]['customer']['name'], 'Test Fleet')
+
+    def test_customer_id_filter(self):
+        """customer_id query param still works after annotation."""
+        customer2 = _make_customer(self.tenant, name='Fleet B', email='b@fleet.com')
+        _make_invoice(self.tenant, self.customer, n_line_items=2)
+        _make_invoice(self.tenant, customer2, n_line_items=4)
+
+        resp = self._get(f'?customer_id={customer2.id}')
+        import json
+        data = json.loads(resp.content)
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(data['invoices'][0]['line_item_count'], 4)
+
+
+# ---------------------------------------------------------------------------
+# Tests: send_invoice_email_batch
+# ---------------------------------------------------------------------------
+
+class SendInvoiceEmailBatchTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.tenant, self.owner = _make_tenant('billing-batch')
+        self.customer = _make_customer(self.tenant, email='fleet@example.com')
+
+    def _post(self, body):
+        import json as _json
+        from apps.billing.views import send_invoice_email_batch
+        req = self.factory.post(
+            '/api/billing/invoices/send-batch/',
+            data=_json.dumps(body),
+            content_type='application/json',
+        )
+        req.user = self.owner
+        req.tenant = self.tenant
+        return send_invoice_email_batch(req)
+
+    @patch('apps.billing.services.invoice_email_service.InvoiceEmailService.send_invoice_email')
+    def test_found_invoices_are_processed(self, mock_send):
+        """Valid invoice IDs get emailed and returned as success."""
+        inv1 = _make_invoice(self.tenant, self.customer, n_line_items=2, status='SENT')
+        inv2 = _make_invoice(self.tenant, self.customer, n_line_items=1, status='DRAFT')
+
+        resp = self._post({'invoice_ids': [inv1.id, inv2.id]})
+        import json
+        data = json.loads(resp.content)
+
+        self.assertEqual(data['sent'], 2)
+        self.assertEqual(data['failed'], 0)
+        self.assertEqual(mock_send.call_count, 2)
+
+    @patch('apps.billing.services.invoice_email_service.InvoiceEmailService.send_invoice_email')
+    def test_unknown_invoice_ids_return_not_found(self, mock_send):
+        """Invoice IDs that don't exist in the tenant return 'Not found' entry."""
+        resp = self._post({'invoice_ids': [99999, 88888]})
+        import json
+        data = json.loads(resp.content)
+
+        self.assertEqual(data['sent'], 0)
+        self.assertEqual(data['failed'], 2)
+        for r in data['results']:
+            self.assertEqual(r['error'], 'Not found')
+        mock_send.assert_not_called()
+
+    @patch('apps.billing.services.invoice_email_service.InvoiceEmailService.send_invoice_email')
+    def test_query_count_bounded_regardless_of_n(self, mock_send):
+        """Batch fetch should use at most 2 DB queries regardless of invoice count."""
+        invoices = [
+            _make_invoice(self.tenant, self.customer, n_line_items=1, status='SENT')
+            for _ in range(6)
+        ]
+        ids = [inv.id for inv in invoices]
+
+        from apps.billing.views import send_invoice_email_batch
+        import json as _json
+        req = self.factory.post(
+            '/api/billing/invoices/send-batch/',
+            data=_json.dumps({'invoice_ids': ids}),
+            content_type='application/json',
+        )
+        req.user = self.owner
+        req.tenant = self.tenant
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = send_invoice_email_batch(req)
+
+        import json
+        data = json.loads(resp.content)
+        self.assertEqual(data['sent'], 6)
+
+        # The key invariant: the number of queries targeting the invoices/
+        # line_items tables must be O(1), not O(N) — two queries regardless
+        # of how many invoice IDs were requested.
+        # (Setup queries like TenantMembership, BillingConfig, EmailBranding
+        # are allowed; we only assert the invoice-fetching is batched.)
+        invoice_queries = [
+            q for q in ctx.captured_queries
+            if 'billing_invoice' in q['sql'] and 'SELECT' in q['sql'].upper()
+        ]
+        self.assertLessEqual(
+            len(invoice_queries), 2,
+            f"Expected ≤2 invoice-related queries for batch of 6, "
+            f"got {len(invoice_queries)}: "
+            f"{[q['sql'][:100] for q in invoice_queries]}"
+        )
+
+    @patch('apps.billing.services.invoice_email_service.InvoiceEmailService.send_invoice_email')
+    def test_cross_tenant_invoice_treated_as_not_found(self, mock_send):
+        """Invoice from a different tenant must not be processed."""
+        tenant2, owner2 = _make_tenant('billing-batch-other')
+        customer2 = _make_customer(tenant2, name='Other', email='other@test.com')
+        inv_other = _make_invoice(tenant2, customer2, n_line_items=1, status='SENT')
+
+        resp = self._post({'invoice_ids': [inv_other.id]})
+        import json
+        data = json.loads(resp.content)
+
+        self.assertEqual(data['sent'], 0)
+        self.assertEqual(data['failed'], 1)
+        self.assertEqual(data['results'][0]['error'], 'Not found')
+        mock_send.assert_not_called()


### PR DESCRIPTION
## Changes

### 🔥 Production hotfix: cache + login resilience
- **Root cause:** RedisCache configured but no Redis on EB → every `@ratelimit` view returned 500
- Falls back to DatabaseCache when no `REDIS_URL` is set
- Rate limiting wrapped in try/except — cache failure degrades gracefully
- LoginAttempt logging made defensive (never crashes login flow)
- Deploy hook runs `createcachetable` automatically
- Suppressed noisy DisallowedHost scanner spam in logs

### 🔑 Admin forgot password
- Registered `admin_password_reset` URL — Django's built-in admin login template already had the link, just needed the URL wired up

### 📈 Scaling guide
- `docs/SCALING.md` — component-by-component thresholds, upgrade paths, cost estimates, env vars for zero-code-change scaling

### 🐛 Billing fixes
- **CODE-037:** Admin `generate_invoices` — cancelled invoices blocked re-billing + `skip_invoicing` flag was ignored
- **CODE-038:** N+1 queries in billing API views (`list_invoices` + `send_invoice_email_batch`)