### PR TITLE
Fix: force DatabaseCache, resilient DRF throttling

### DIFF
--- a/common/throttles.py
+++ b/common/throttles.py
@@ -1,0 +1,29 @@
+"""
+Resilient throttle classes that degrade gracefully if the cache backend
+is misconfigured or unavailable. DRF's built-in throttles crash with a
+500 if cache.get() raises — these catch the exception and allow the
+request through (better to skip rate-limiting than to block all API access).
+"""
+
+import logging
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+logger = logging.getLogger(__name__)
+
+
+class ResilientAnonRateThrottle(AnonRateThrottle):
+    def allow_request(self, request, view):
+        try:
+            return super().allow_request(request, view)
+        except Exception:
+            logger.warning("AnonRateThrottle unavailable (cache backend error)")
+            return True
+
+
+class ResilientUserRateThrottle(UserRateThrottle):
+    def allow_request(self, request, view):
+        try:
+            return super().allow_request(request, view)
+        except Exception:
+            logger.warning("UserRateThrottle unavailable (cache backend error)")
+            return True

--- a/rs_systems/settings/base.py
+++ b/rs_systems/settings/base.py
@@ -106,8 +106,8 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ],
     'DEFAULT_THROTTLE_CLASSES': [
-        'rest_framework.throttling.AnonRateThrottle',
-        'rest_framework.throttling.UserRateThrottle',
+        'common.throttles.ResilientAnonRateThrottle',
+        'common.throttles.ResilientUserRateThrottle',
     ],
     'DEFAULT_THROTTLE_RATES': {
         'anon': '20/minute',

--- a/rs_systems/settings/production.py
+++ b/rs_systems/settings/production.py
@@ -145,32 +145,22 @@ CSRF_TRUSTED_ORIGINS = [
 # across multiple workers (unlike LocMemCache which is per-process).
 # django-ratelimit, DRF throttling, and template caching all depend on this.
 
-_REDIS_URL = os.environ.get('REDIS_CACHE_URL') or os.environ.get('REDIS_URL')
-
-if _REDIS_URL:
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
-            'LOCATION': _REDIS_URL,
-            'KEY_PREFIX': 'rs_systems',
-            'TIMEOUT': 300,
-        }
+# Database-backed cache — no external dependencies, works across multiple
+# gunicorn workers, survives process restarts. The django_cache table is
+# created by the postdeploy hook (createcachetable).
+#
+# To upgrade to Redis later: install redis package, add REDIS_URL env var,
+# and swap the backend. See docs/SCALING.md for details.
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'django_cache',
+        'TIMEOUT': 300,
+        'OPTIONS': {
+            'MAX_ENTRIES': 5000,
+        },
     }
-else:
-    # Database-backed cache — no external dependencies, works with multiple
-    # gunicorn workers, and survives process restarts. Requires the cache
-    # table to exist (created by migrate via createcachetable or the
-    # migration we ship).
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
-            'LOCATION': 'django_cache',
-            'TIMEOUT': 300,
-            'OPTIONS': {
-                'MAX_ENTRIES': 5000,
-            },
-        }
-    }
+}
 
 # =========================================
 # EMAIL (Production overrides)


### PR DESCRIPTION
Redis module not installed on EB but cache was still resolving to RedisCache. All API endpoints crashed with 500 on throttle check.

- Force DatabaseCache (no Redis conditional)
- Custom throttle classes that degrade gracefully on cache failure
- Every API endpoint now resilient to cache issues