### PR TITLE
UX: Add 'Not sure yet' to plan selection at signup

### DIFF
--- a/apps/saas/forms.py
+++ b/apps/saas/forms.py
@@ -81,6 +81,8 @@ class SignupForm(forms.Form):
             (p.slug, p.name)
             for p in SubscriptionPlan.objects.filter(is_active=True).exclude(slug='trial').order_by('display_order')
         ]
+        plan_choices.append(('not_sure', "Not sure yet"))
+
         self.fields['plan'].choices = plan_choices
 
     def clean_email(self):

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -261,7 +261,7 @@ def signup_view(request):
                 tenant = result['tenant']
 
                 # Save intended plan if selected
-                if cd.get('plan'):
+                if cd.get('plan') and cd['plan'] != 'not_sure':
                     tenant.intended_plan = cd['plan']
                     tenant.save(update_fields=['intended_plan'])
 


### PR DESCRIPTION
Adds a 'Not sure yet' option to the plan dropdown. Selecting it doesn't save an intended_plan on the tenant (so no false upgrade prompts on dashboard).