### PR TITLE
Plan selection UX: pre-select, nudge emails, not-sure-yet option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to RS Systems are documented here.
 ## [Unreleased] — 2026-03-21
 
 ### Added
+- **"Not sure yet" plan option at signup** — users who don't know which plan they want can skip the decision and explore during trial
+- **Intended plan pre-selection on billing page** — if a user chose a plan at signup, it's highlighted with a "Recommended for you" badge and pulsing border on the billing/upgrade page
+- **Stripe Checkout plan default** — the Upgrade button falls back to the user's intended plan from signup, reducing friction at checkout
+- **Day 20 nudge email for undecided signups** — tenants who chose "Not sure yet" get a friendly email when 10 days remain on trial, linking to the pricing page
 - **Void invoice action** — owners can void invoices from both the bulk action bar (invoice list) and individual invoice detail page. Voiding sets status to CANCELLED. Paid and already-voided invoices are skipped.
 - **Delete voided invoices** — the delete action now accepts both DRAFT and CANCELLED (voided) invoices. Active invoices must be voided first before deletion.
 - New URL: `POST /owner/invoices/<id>/void/` for single-invoice void
+- Proposal: AI-powered plan recommendation based on shop usage data (`docs/proposals/ai-plan-recommendation.md`)
 
 ### Changed
 - Bulk action bar: "Delete Drafts" renamed to "Delete" with updated confirmation text explaining void-first workflow

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -754,7 +754,7 @@ def billing_view(request):
 
         try:
             if action == 'upgrade':
-                plan_slug = request.POST.get('plan')
+                plan_slug = request.POST.get('plan') or tenant.intended_plan
                 if plan_slug:
                     base_url = request.build_absolute_uri('/').rstrip('/')
                     result = svc.create_subscription(tenant, plan_slug, base_url=base_url)
@@ -813,6 +813,7 @@ def billing_view(request):
         'current_plan': tenant.subscription_plan,
         'is_trial': tenant.plan == 'trial',
         'trial_days_remaining': tenant.trial_days_remaining,
+        'intended_plan': tenant.intended_plan if tenant.intended_plan and tenant.intended_plan != tenant.plan else '',
     }
     return render(request, 'saas/billing.html', context)
 

--- a/apps/tenants/management/commands/check_subscription_alerts.py
+++ b/apps/tenants/management/commands/check_subscription_alerts.py
@@ -36,6 +36,7 @@ ALERT_SUB_EXPIRED = 'subscription_expired'
 ALERT_GRACE_15_DAYS = 'grace_period_15_days'
 ALERT_GRACE_5_DAYS = 'grace_period_5_days'
 ALERT_GRACE_ENDED = 'grace_period_ended'
+ALERT_TRIAL_PLAN_NUDGE = 'trial_plan_nudge'
 
 
 def _get_recipient_emails(tenant):
@@ -172,6 +173,27 @@ class Command(BaseCommand):
                         f"({tenant.trial_expiry.strftime('%B %d, %Y')}).\n\n"
                         f"Don't lose access to your shop data! Upgrade today:\n"
                         f"https://rssystems.io/owner/billing/\n\n"
+                        f"— RS Systems"
+                    ),
+                    dry_run=dry_run,
+                ):
+                    sent += 1
+
+        # --- Nudge email for 'not sure' signups around day 20 ---
+        if (tenant.plan == 'trial' and tenant.trial_expiry and not tenant.is_trial_expired
+                and not tenant.intended_plan):
+            days_until_expiry = (tenant.trial_expiry.date() - today).days
+            if 0 < days_until_expiry <= 10:
+                if _send_alert(
+                    tenant, ALERT_TRIAL_PLAN_NUDGE,
+                    subject=f"Which plan is right for {tenant.name}?",
+                    body=(
+                        f"Hi {_owner_name(tenant)},\n\n"
+                        f"Your trial has {days_until_expiry} day{'s' if days_until_expiry != 1 else ''} left. "
+                        f"Browse our plans to find the right fit for your shop:\n"
+                        f"https://rssystems.io/pricing/\n\n"
+                        f"We have options for shops of all sizes — from solo techs to "
+                        f"large fleets. Take a look and pick the plan that works for you.\n\n"
                         f"— RS Systems"
                     ),
                     dry_run=dry_run,

--- a/docs/proposals/ai-plan-recommendation.md
+++ b/docs/proposals/ai-plan-recommendation.md
@@ -1,0 +1,128 @@
+# Proposal: AI-Powered Plan Recommendation
+
+**Author:** Amelia  
+**Date:** 2026-03-21  
+**Status:** Draft — awaiting Drake's review
+
+---
+
+## Problem
+
+New shop owners signing up for RS Systems don't always know which plan fits their business. We already see this — the "Not sure yet" option exists because people hesitate. Even those who pick a plan at signup may not be choosing optimally for their actual usage patterns.
+
+Once a shop has been using the trial for 2-3 weeks, we have real data about their business: number of techs, customers, repairs, invoices, whether they use features like rewards or Stripe Connect. That data can drive a personalized recommendation that's more useful than a static pricing page.
+
+## Solution
+
+Add an AI-powered plan recommendation engine that analyzes a tenant's actual usage during trial and suggests the best-fit plan.
+
+### Data Points for Recommendation
+
+| Signal | What It Tells Us |
+|--------|-----------------|
+| Number of technicians added | Team size → Solo vs Starter vs Pro |
+| Number of customers | Account volume → capacity needs |
+| Repairs completed per week | Throughput → will they hit limits? |
+| Invoices generated | Whether they use billing features |
+| Stripe Connect set up | Payment sophistication |
+| Rewards/referrals used | Feature engagement |
+| Storage used (photos) | Media-heavy shops need more |
+| Number of active users | Multi-user = higher tier |
+
+### Recommendation Logic (Rule-Based First, ML Later)
+
+**Phase 1 — Rule-based (no external dependencies):**
+
+```python
+def recommend_plan(tenant):
+    """Analyze tenant usage and recommend a plan."""
+    stats = {
+        'techs': tenant.technicians.count(),
+        'customers': tenant.customers.count(),
+        'monthly_repairs': tenant.repairs.filter(
+            completed_at__gte=now() - timedelta(days=30)
+        ).count(),
+        'uses_invoicing': tenant.invoices.exists(),
+        'uses_rewards': tenant.reward_entries.exists(),
+        'uses_connect': tenant.can_accept_payments,
+        'storage_mb': tenant.get_storage_used_mb(),
+    }
+    
+    # Project monthly usage from trial activity
+    trial_days = (now() - tenant.trial_started_at).days or 1
+    projected_monthly_repairs = (stats['monthly_repairs'] / trial_days) * 30
+    
+    if (stats['techs'] > 5 or projected_monthly_repairs > 200 
+            or stats['uses_connect'] or stats['customers'] > 50):
+        return 'enterprise', "Your shop's volume and team size need Enterprise-level capacity."
+    
+    if (stats['techs'] > 2 or projected_monthly_repairs > 50
+            or stats['uses_invoicing'] or stats['uses_rewards']):
+        return 'pro', "You're using advanced features and growing fast — Pro gives you room."
+    
+    if stats['techs'] >= 1 or projected_monthly_repairs > 10:
+        return 'starter', "Perfect for a shop your size — all the essentials, no extras you don't need."
+    
+    return 'starter', "Start here — you can always upgrade as your shop grows."
+```
+
+**Phase 2 — Enhanced with LLM (future):**
+- Feed usage stats to an LLM for natural language explanation
+- "Based on your 47 repairs this month with 3 techs, Pro gives you unlimited repairs and team seats"
+- Personalized to the shop's actual workflow, not generic marketing copy
+
+### Where It Shows Up
+
+1. **Billing page** — "Recommended for you" badge with explanation below plan card
+2. **Day 20 nudge email** — for "not sure" signups, include the AI recommendation
+3. **Trial expiry emails** — include recommendation in the "time to upgrade" emails
+4. **Owner dashboard** — subtle banner: "Based on your usage, we think [Plan] is your best fit"
+
+### API Endpoint
+
+```
+GET /api/tenants/plan-recommendation/
+Response: {
+    "recommended_plan": "pro",
+    "reason": "You're using advanced features and growing fast...",
+    "usage_summary": { ... },
+    "confidence": "high"  // high/medium/low based on data volume
+}
+```
+
+Confidence levels:
+- **High:** 14+ days of activity, 10+ repairs
+- **Medium:** 7-13 days, 3-9 repairs
+- **Low:** <7 days or <3 repairs (too early to tell — show all plans equally)
+
+## Scope
+
+### Phase 1 (rule-based, can ship in a day)
+- `PlanRecommendationService` in `apps/tenants/services.py`
+- Recommendation logic based on usage stats (no external API calls)
+- Display on billing page as "Recommended" badge
+- Include in nudge email
+- API endpoint for future frontend use
+
+### Phase 2 (LLM-enhanced, future)
+- Natural language explanations via API (Anthropic/OpenAI)
+- A/B test rule-based vs LLM explanations for conversion
+- Feedback loop: track if users follow recommendations
+
+## Risk
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Bad recommendation hurts trust | Medium | Show confidence level; don't recommend on low data |
+| Over-engineering for current scale | Low | Phase 1 is ~100 lines of code, no dependencies |
+| Privacy concern (analyzing usage) | Low | Standard SaaS analytics; no PII in recommendation |
+| Recommendation feels pushy | Medium | Subtle UI; "suggestion" language, not hard sell |
+
+## Cost
+
+- Phase 1: Zero. Pure Python logic, no external APIs.
+- Phase 2: ~$0.01 per recommendation (one LLM call per billing page view, cached per session).
+
+## Decision Needed
+
+Drake: approve Phase 1 (rule-based) to ship alongside the nudge email work? Phase 2 can wait until we have enough tenants to validate whether recommendations improve conversion.

--- a/templates/saas/billing.html
+++ b/templates/saas/billing.html
@@ -4,6 +4,14 @@
 
 {% block content %}
 
+<style>
+@keyframes pulse-border {
+    0%, 100% { border-color: rgb(168 85 247); box-shadow: 0 0 0 0 rgba(168, 85, 247, 0.4); }
+    50% { border-color: rgb(147 51 234); box-shadow: 0 0 0 4px rgba(168, 85, 247, 0); }
+}
+.animate-pulse-border { animation: pulse-border 2s ease-in-out infinite; }
+</style>
+
 <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-900">Billing & Plans</h1>
     <p class="text-gray-500 mt-1">Manage your subscription and payment method</p>
@@ -195,12 +203,18 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-{{ plans|length }} gap-4">
         {% for plan in plans %}
         <div class="bg-white rounded-xl border-2 p-6 shadow-sm relative
-            {% if plan.slug == tenant.plan %}border-blue-500{% elif plan.slug == 'pro' %}border-green-400{% else %}border-gray-200{% endif %}">
+            {% if plan.slug == tenant.plan %}border-blue-500{% elif intended_plan and plan.slug == intended_plan %}border-purple-500 animate-pulse-border{% elif plan.slug == 'pro' %}border-green-400{% else %}border-gray-200{% endif %}">
 
             {% if plan.slug == tenant.plan %}
             <div class="absolute -top-3 left-1/2 transform -translate-x-1/2">
                 <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-blue-600 text-white">
                     Current Plan
+                </span>
+            </div>
+            {% elif intended_plan and plan.slug == intended_plan %}
+            <div class="absolute -top-3 left-1/2 transform -translate-x-1/2">
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-purple-600 text-white">
+                    Recommended for you
                 </span>
             </div>
             {% elif plan.slug == 'pro' %}


### PR DESCRIPTION
## Changes

### Signup
- **'Not sure yet' option** on plan selection at signup (previous commit)

### Billing Page
- **Intended plan pre-selection** — plan chosen at signup gets a purple 'Recommended for you' badge with pulsing border animation
- **Stripe Checkout default** — upgrade action falls back to intended_plan when no explicit plan selected, so dashboard Upgrade button works seamlessly

### Lifecycle Emails  
- **Day 20 nudge email** for tenants who chose 'Not sure yet' — fires when 1-10 trial days remain, links to /pricing/

### Docs
- CHANGELOG updated
- Proposal added: AI-powered plan recommendation based on shop usage (`docs/proposals/ai-plan-recommendation.md`)

### Tests
All 77 targeted tests pass.