### PR TITLE
CODE-128/129/130: billing email fix, role ordering, remove AR defaults

### DIFF
--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -65,11 +65,25 @@ def _get_owner_tenant(request):
     """
     tenant = getattr(request, 'tenant', None)
     if not tenant:
+        # Use explicit priority ordering so 'owner' always beats 'manager' —
+        # alphabetical order_by('role') puts 'manager' first (m < o), which
+        # would return a manager membership at Shop B rather than an owner
+        # membership at Shop A for users who belong to multiple shops.
+        # Mirrors the annotation pattern in common/auth._get_membership. (CODE-129)
+        from django.db.models import Case, When, IntegerField, Value
         membership = (
             TenantMembership.objects
             .filter(user=request.user, is_active=True, role__in=['owner', 'manager'])
             .select_related('tenant')
-            .order_by('role')
+            .annotate(
+                role_priority=Case(
+                    When(role='owner', then=Value(0)),
+                    When(role='manager', then=Value(1)),
+                    default=Value(99),
+                    output_field=IntegerField(),
+                )
+            )
+            .order_by('role_priority')
             .first()
         )
         if membership:

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -684,13 +684,8 @@ def owner_dashboard(request):
     # is ambiguous — a shop owner may legitimately charge $50 per repair.
     # The "Finish setting up your shop" banner was persisting even after full setup
     # because pricing_is_default was True even for correctly configured shops. (CODE-110)
-    if not has_tax_rates:
-        setup_steps.append({
-            'label': 'Configure sales tax',
-            'desc': 'Tax is disabled until you add a tax rate for your area',
-            'url': '/owner/settings/?tab=billing',
-            'icon': 'fas fa-receipt',
-        })
+    # Tax step intentionally removed from setup checklist — tax is optional
+    # and many shops don't charge tax. Owners can configure it in Settings → Billing.
     if not has_customers:
         setup_steps.append({
             'label': 'Add your first customer',
@@ -1329,7 +1324,7 @@ def owner_settings_view(request):
                     except (InvalidOperation, ValueError):
                         return Decimal(default)
 
-                config.state_tax_rate = _dec('state_tax_rate', '6.500')
+                config.state_tax_rate = _dec('state_tax_rate', '0')
                 config.county_tax_rate = _dec('county_tax_rate', '0')
                 config.city_tax_rate = _dec('city_tax_rate', '0')
                 config.special_tax_rate = _dec('special_tax_rate', '0')

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -2788,12 +2788,23 @@ def owner_send_reminder(request, invoice_id):
         return redirect('signup')
 
     invoice = get_object_or_404(Invoice, id=invoice_id, customer__tenant=tenant)
-    
+
     if invoice.status in ['PAID', 'CANCELLED', 'DRAFT']:
         messages.error(request, f'Cannot send reminder for {invoice.get_status_display().lower()} invoice.')
         return redirect('owner_invoice_detail', invoice_id=invoice.id)
 
-    if not invoice.customer.email:
+    # Resolve the actual recipient — prefer CustomerRepairPreference.billing_email
+    # over customer.email so fleet customers with a dedicated AP address receive the
+    # reminder at the right inbox.  (CODE-128: guard was checking customer.email only,
+    # which blocked reminders for customers whose *only* email is billing_email.)
+    _reminder_recipient = None
+    try:
+        _reminder_prefs = invoice.customer.repair_preferences
+        _reminder_recipient = _reminder_prefs.billing_email or invoice.customer.email
+    except Exception:
+        _reminder_recipient = invoice.customer.email
+
+    if not _reminder_recipient:
         messages.error(request, 'No email address found for this customer.')
         return redirect('owner_invoice_detail', invoice_id=invoice.id)
 
@@ -2803,23 +2814,24 @@ def owner_send_reminder(request, invoice_id):
     try:
         from apps.billing.services.reminder_service import ReminderService
         reminder_service = ReminderService(tenant=tenant)
-        
+
         # Determine reminder type based on invoice status
         if invoice.status == 'OVERDUE' or (invoice.due_date and invoice.due_date < timezone.now().date()):
             reminder_type = 'overdue'
         else:
             reminder_type = 'due_soon'
-        
+
         result = reminder_service.send_reminder(
             invoice, reminder_type,
             custom_body=custom_message if custom_message else None,
         )
-        
+
         if result.get('success'):
-            messages.success(request, f'Payment reminder sent to {invoice.customer.email}.')
+            # Show the actual recipient address so the owner knows where it went
+            messages.success(request, f'Payment reminder sent to {_reminder_recipient}.')
         else:
             messages.error(request, f'Failed to send reminder: {result.get("error", "Unknown error")}')
-            
+
     except Exception as e:
         logger.error(f"Error sending reminder for invoice {invoice.invoice_number}: {e}")
         messages.error(request, 'An error occurred while sending the reminder.')

--- a/templates/saas/owner_settings.html
+++ b/templates/saas/owner_settings.html
@@ -584,7 +584,7 @@
                     <div>
                         <label class="block text-xs font-medium text-gray-500 mb-1">State %</label>
                         <input type="number" name="state_tax_rate" id="state_tax_rate"
-                            value="{{ billing_config.state_tax_rate|default:'6.500' }}"
+                            value="{{ billing_config.state_tax_rate|default:'0' }}"
                             step="0.001" min="0" max="20"
                             oninput="updateTaxTotal()"
                             class="w-full px-3 py-2.5 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm">

--- a/templates/saas/owner_setup.html
+++ b/templates/saas/owner_setup.html
@@ -296,7 +296,7 @@
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">State (2-letter)</label>
-                <input type="text" name="state" value="{{ billing_config.company_state|default:'AR' }}"
+                <input type="text" name="state" value="{{ billing_config.company_state|default:'' }}"
                        maxlength="2"
                        class="form-input w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-400 focus:ring focus:ring-blue-100 focus:outline-none uppercase"
                        placeholder="AR">
@@ -305,7 +305,7 @@
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
               <div>
                 <label class="block text-xs font-medium text-gray-600 mb-1">State Rate %</label>
-                <input type="number" name="state_rate" value="{{ billing_config.state_tax_rate|default:'6.500' }}"
+                <input type="number" name="state_rate" value="{{ billing_config.state_tax_rate|default:'0' }}"
                        step="0.001" min="0" max="20"
                        class="form-input w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-400 focus:ring focus:ring-blue-100 focus:outline-none">
               </div>

--- a/templates/saas/owner_tax_rates.html
+++ b/templates/saas/owner_tax_rates.html
@@ -71,7 +71,7 @@
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
                 <div>
                     <label class="block text-xs font-medium text-gray-600 mb-1">State Rate %</label>
-                    <input type="number" name="state_rate" value="6.500" step="0.001" min="0"
+                    <input type="number" name="state_rate" value="0" step="0.001" min="0"
                            class="rate-input w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                            oninput="updateTotal(this.closest('form'))">
                 </div>
@@ -96,7 +96,7 @@
             </div>
             <div class="flex items-center justify-between">
                 <div class="text-sm text-gray-600">
-                    Total: <span class="font-bold text-lg text-gray-900 total-display">6.500%</span>
+                    Total: <span class="font-bold text-lg text-gray-900 total-display">0.000%</span>
                 </div>
                 <button type="submit" class="bg-blue-600 text-white text-sm font-medium px-5 py-2 rounded-lg hover:bg-blue-700 transition-colors">
                     <i class="fas fa-plus mr-1"></i> Add Rate

--- a/tests/bug_fixes/test_code128_owner_send_reminder_billing_email.py
+++ b/tests/bug_fixes/test_code128_owner_send_reminder_billing_email.py
@@ -1,0 +1,290 @@
+"""
+CODE-128: owner_send_reminder() used customer.email for guard and success message.
+
+Bug:
+- owner_send_reminder() checked `if not invoice.customer.email:` to block reminders.
+- A fleet customer who has ONLY a billing_email on CustomerRepairPreference (no
+  customer.email) would get "No email address found" error and the reminder would
+  never be sent — even though ReminderService.send_reminder() could deliver it.
+- The success message showed `invoice.customer.email` instead of the actual
+  recipient address, so the owner saw the wrong email in their confirmation toast.
+
+Fix:
+- Resolve recipient email before the guard: prefer prefs.billing_email or customer.email
+- Check the resolved address (not customer.email directly) for the no-email guard
+- Show resolved address in the success message so owner sees where it actually went
+"""
+
+from unittest.mock import patch
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import User
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.utils import timezone
+
+from apps.tenants.models import Tenant, TenantMembership
+from apps.billing.models import Invoice, BillingConfig
+from core.models import Customer
+from apps.customer_portal.models import CustomerRepairPreference
+
+
+def _make_request_with_messages(user, tenant, data=None):
+    """Helper: authenticated POST request with tenant + message middleware."""
+    factory = RequestFactory()
+    request = factory.post('/owner/invoices/1/reminder/', data or {})
+    request.user = user
+    request.tenant = tenant
+    setattr(request, 'session', {})
+    messages = FallbackStorage(request)
+    setattr(request, '_messages', messages)
+    return request
+
+
+class OwnerSendReminderBillingEmailTest(TestCase):
+    """Tests for CODE-128: owner_send_reminder billing_email guard and success message."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            username='owner_code128', email='owner128@example.com', password='pass'
+        )
+        self.tenant = Tenant.objects.create(
+            name='Test Shop 128', slug='test-shop-128', plan='starter', is_active=True,
+            owner=self.owner,
+        )
+        TenantMembership.objects.create(
+            user=self.owner, tenant=self.tenant, role='owner', is_active=True,
+        )
+        self.customer_with_email = Customer.objects.create(
+            tenant=self.tenant, name='Regular Fleet', email='fleet@example.com',
+        )
+        # billing_only: no customer.email — use None to avoid unique constraint on ''
+        self.customer_billing_only = Customer.objects.create(
+            tenant=self.tenant, name='AP-Only Fleet', email=None,
+        )
+        # no_email: will be cleared in the specific test
+        self.customer_no_email = Customer.objects.create(
+            tenant=self.tenant, name='No Email Fleet', email='placeholder128@example.com',
+        )
+        BillingConfig.get_for_tenant(self.tenant)
+
+        today = timezone.now().date()
+        self.invoice_sent = Invoice.objects.create(
+            tenant=self.tenant,
+            customer=self.customer_with_email,
+            invoice_number='INV-128-001',
+            invoice_date=today - timezone.timedelta(days=10),
+            due_date=today + timezone.timedelta(days=5),
+            total=300.00,
+            amount_paid=0.00,
+            status='SENT',
+        )
+        self.invoice_billing_only = Invoice.objects.create(
+            tenant=self.tenant,
+            customer=self.customer_billing_only,
+            invoice_number='INV-128-002',
+            invoice_date=today - timezone.timedelta(days=10),
+            due_date=today + timezone.timedelta(days=5),
+            total=200.00,
+            amount_paid=0.00,
+            status='SENT',
+        )
+        self.invoice_no_email = Invoice.objects.create(
+            tenant=self.tenant,
+            customer=self.customer_no_email,
+            invoice_number='INV-128-003',
+            invoice_date=today - timezone.timedelta(days=10),
+            due_date=today + timezone.timedelta(days=5),
+            total=100.00,
+            amount_paid=0.00,
+            status='SENT',
+        )
+
+    # -------------------------------------------------------------------------
+    # Customer with only customer.email (no billing_email) — baseline
+    # -------------------------------------------------------------------------
+
+    @patch('apps.billing.services.reminder_service.ReminderService.send_reminder')
+    def test_sends_reminder_to_customer_email(self, mock_send):
+        """Reminder is sent to customer.email when no billing_email exists."""
+        mock_send.return_value = {'success': True}
+        request = _make_request_with_messages(self.owner, self.tenant)
+
+        from apps.saas.views import owner_send_reminder
+        owner_send_reminder(request, self.invoice_sent.id)
+
+        mock_send.assert_called_once()
+        msgs = list(request._messages)
+        self.assertTrue(
+            any('fleet@example.com' in str(m) for m in msgs),
+            f"Expected fleet@example.com in messages, got: {[str(m) for m in msgs]}"
+        )
+
+    # -------------------------------------------------------------------------
+    # Customer with billing_email only (no customer.email)
+    # -------------------------------------------------------------------------
+
+    @patch('apps.billing.services.reminder_service.ReminderService.send_reminder')
+    def test_sends_reminder_to_billing_email_when_no_customer_email(self, mock_send):
+        """
+        BUG: customer.email is empty but billing_email is set.
+        Pre-fix: guard checked customer.email → blocked with 'No email address found'.
+        Post-fix: guard checks resolved address (billing_email) → reminder goes through.
+        """
+        CustomerRepairPreference.objects.create(
+            customer=self.customer_billing_only,
+            billing_email='ap@apfleet.com',
+        )
+        mock_send.return_value = {'success': True}
+        request = _make_request_with_messages(self.owner, self.tenant)
+
+        from apps.saas.views import owner_send_reminder
+        owner_send_reminder(request, self.invoice_billing_only.id)
+
+        # Should NOT block with 'No email address found'
+        msgs = list(request._messages)
+        msg_texts = [str(m) for m in msgs]
+        self.assertFalse(
+            any('No email address found' in t for t in msg_texts),
+            f"Should not block when billing_email is set, got: {msg_texts}"
+        )
+        # ReminderService.send_reminder() should have been called
+        mock_send.assert_called_once()
+
+    @patch('apps.billing.services.reminder_service.ReminderService.send_reminder')
+    def test_success_message_shows_billing_email_not_customer_email(self, mock_send):
+        """
+        BUG: success message used invoice.customer.email.
+        Post-fix: message shows the actual recipient (billing_email when set).
+        """
+        CustomerRepairPreference.objects.create(
+            customer=self.customer_with_email,
+            billing_email='accounts-payable@fleet.com',
+        )
+        mock_send.return_value = {'success': True}
+        request = _make_request_with_messages(self.owner, self.tenant)
+
+        from apps.saas.views import owner_send_reminder
+        owner_send_reminder(request, self.invoice_sent.id)
+
+        msgs = list(request._messages)
+        msg_texts = [str(m) for m in msgs]
+        # Should mention billing_email
+        self.assertTrue(
+            any('accounts-payable@fleet.com' in t for t in msg_texts),
+            f"Expected billing email in message, got: {msg_texts}"
+        )
+        # Should NOT show the old customer.email in the success message
+        self.assertFalse(
+            any('fleet@example.com' in t for t in msg_texts),
+            f"Should show billing_email, not customer.email, got: {msg_texts}"
+        )
+
+    # -------------------------------------------------------------------------
+    # Customer with neither email (should still block with clear error)
+    # -------------------------------------------------------------------------
+
+    @patch('apps.billing.services.reminder_service.ReminderService.send_reminder')
+    def test_blocks_when_no_email_at_all(self, mock_send):
+        """When both customer.email and billing_email are empty, show error."""
+        # Clear the placeholder email
+        self.customer_no_email.email = ''
+        self.customer_no_email.save()
+        request = _make_request_with_messages(self.owner, self.tenant)
+
+        from apps.saas.views import owner_send_reminder
+        owner_send_reminder(request, self.invoice_no_email.id)
+
+        msgs = list(request._messages)
+        msg_texts = [str(m) for m in msgs]
+        self.assertTrue(
+            any('No email address found' in t for t in msg_texts),
+            f"Expected 'No email' message, got: {msg_texts}"
+        )
+        mock_send.assert_not_called()
+
+    # -------------------------------------------------------------------------
+    # Status guards still work
+    # -------------------------------------------------------------------------
+
+    @patch('apps.billing.services.reminder_service.ReminderService.send_reminder')
+    def test_blocks_paid_invoice(self, mock_send):
+        """Cannot send reminder for PAID invoice."""
+        paid_invoice = Invoice.objects.create(
+            tenant=self.tenant,
+            customer=self.customer_with_email,
+            invoice_number='INV-128-PAID',
+            invoice_date=timezone.now().date(),
+            due_date=timezone.now().date(),
+            total=100.00,
+            amount_paid=100.00,
+            status='PAID',
+        )
+        request = _make_request_with_messages(self.owner, self.tenant)
+
+        from apps.saas.views import owner_send_reminder
+        owner_send_reminder(request, paid_invoice.id)
+
+        mock_send.assert_not_called()
+        msgs = list(request._messages)
+        self.assertTrue(any('paid' in str(m).lower() for m in msgs))
+
+    @patch('apps.billing.services.reminder_service.ReminderService.send_reminder')
+    def test_blocks_draft_invoice(self, mock_send):
+        """Cannot send reminder for DRAFT invoice."""
+        draft_invoice = Invoice.objects.create(
+            tenant=self.tenant,
+            customer=self.customer_with_email,
+            invoice_number='INV-128-DRAFT',
+            invoice_date=timezone.now().date(),
+            due_date=timezone.now().date(),
+            total=100.00,
+            amount_paid=0.00,
+            status='DRAFT',
+        )
+        request = _make_request_with_messages(self.owner, self.tenant)
+
+        from apps.saas.views import owner_send_reminder
+        owner_send_reminder(request, draft_invoice.id)
+
+        mock_send.assert_not_called()
+
+    @patch('apps.billing.services.reminder_service.ReminderService.send_reminder')
+    def test_handles_reminder_service_failure(self, mock_send):
+        """When ReminderService returns failure, show error message."""
+        mock_send.return_value = {'success': False, 'error': 'SMTP error'}
+        request = _make_request_with_messages(self.owner, self.tenant)
+
+        from apps.saas.views import owner_send_reminder
+        owner_send_reminder(request, self.invoice_sent.id)
+
+        msgs = list(request._messages)
+        msg_texts = [str(m) for m in msgs]
+        self.assertTrue(
+            any('Failed' in t or 'SMTP' in t for t in msg_texts),
+            f"Expected failure message, got: {msg_texts}"
+        )
+
+    @patch('apps.billing.services.reminder_service.ReminderService.send_reminder')
+    def test_billing_email_takes_priority_over_customer_email(self, mock_send):
+        """When both customer.email and billing_email are set, billing_email wins."""
+        CustomerRepairPreference.objects.create(
+            customer=self.customer_with_email,
+            billing_email='billing@fleet-ap.com',
+        )
+        mock_send.return_value = {'success': True}
+        request = _make_request_with_messages(self.owner, self.tenant)
+
+        from apps.saas.views import owner_send_reminder
+        owner_send_reminder(request, self.invoice_sent.id)
+
+        msgs = list(request._messages)
+        msg_texts = [str(m) for m in msgs]
+        # billing_email should appear in success
+        self.assertTrue(
+            any('billing@fleet-ap.com' in t for t in msg_texts),
+            f"Expected billing email in message, got: {msg_texts}"
+        )
+        # customer.email should NOT appear
+        self.assertFalse(
+            any('fleet@example.com' in t for t in msg_texts),
+            f"Should show billing_email, not customer.email, got: {msg_texts}"
+        )

--- a/tests/bug_fixes/test_code129_get_owner_tenant_role_ordering.py
+++ b/tests/bug_fixes/test_code129_get_owner_tenant_role_ordering.py
@@ -1,0 +1,171 @@
+"""
+CODE-129: _get_owner_tenant() used .order_by('role') — alphabetical, not priority.
+
+Bug:
+- _get_owner_tenant() in apps/saas/views.py is called with no tenant context when
+  the tenant middleware fails to resolve a tenant from the request.
+- The fallback branch filtered TenantMembership to role__in=['owner', 'manager']
+  and called .order_by('role') to pick the "best" membership.
+- Alphabetical ordering puts 'manager' before 'owner' (m < o).
+- A user who is an **owner** at Shop A AND a **manager** at Shop B would get the
+  manager-at-Shop-B membership returned instead of the owner-at-Shop-A one.
+- This means the owner dashboard would silently show Shop B data instead of Shop A.
+
+Fix (CODE-129):
+- Replace .order_by('role') with an annotated priority ordering (owner=0, manager=1),
+  consistent with the priority logic already used in common.auth._get_membership.
+
+Tests:
+1. Single-owner user → returns owner membership (unchanged, regression guard).
+2. Single-manager user → returns manager membership.
+3. Owner at Shop A + manager at Shop B → returns OWNER (Shop A), not manager (Shop B).
+4. Manager at Shop A + owner at Shop B → returns OWNER (Shop B), not manager (Shop A).
+5. Viewer/technician user → returns (None, None).
+"""
+
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import User
+
+from apps.tenants.models import Tenant, TenantMembership
+
+
+def _make_request(user):
+    """Authenticated request with NO tenant context (tests the fallback branch)."""
+    factory = RequestFactory()
+    request = factory.get('/owner/')
+    request.user = user
+    # Deliberately do NOT set request.tenant — tests the no-tenant fallback branch.
+    return request
+
+
+class GetOwnerTenantRoleOrderingTest(TestCase):
+    """Regression tests for CODE-129: _get_owner_tenant() role priority ordering."""
+
+    def setUp(self):
+        from apps.saas.views import _get_owner_tenant
+        self._get_owner_tenant = _get_owner_tenant
+
+        # Shop A — our "primary" shop
+        self.owner_a = User.objects.create_user(
+            username='owner_a_129', email='owner_a_129@example.com', password='pass'
+        )
+        self.shop_a = Tenant.objects.create(
+            name='Shop A 129', slug='shop-a-129', plan='starter', is_active=True,
+            owner=self.owner_a,
+        )
+
+        # Shop B — secondary shop
+        self.owner_b = User.objects.create_user(
+            username='owner_b_129', email='owner_b_129@example.com', password='pass'
+        )
+        self.shop_b = Tenant.objects.create(
+            name='Shop B 129', slug='shop-b-129', plan='starter', is_active=True,
+            owner=self.owner_b,
+        )
+
+        # Multi-shop user (the bug target)
+        self.multi_user = User.objects.create_user(
+            username='multi_129', email='multi_129@example.com', password='pass'
+        )
+
+    # -----------------------------------------------------------------
+    # 1. Single owner — baseline regression guard
+    # -----------------------------------------------------------------
+    def test_single_owner_returns_correct_membership(self):
+        TenantMembership.objects.create(
+            user=self.owner_a, tenant=self.shop_a, role='owner', is_active=True,
+        )
+        request = _make_request(self.owner_a)
+        tenant, membership = self._get_owner_tenant(request)
+        self.assertIsNotNone(tenant)
+        self.assertEqual(tenant, self.shop_a)
+        self.assertEqual(membership.role, 'owner')
+
+    # -----------------------------------------------------------------
+    # 2. Single manager — should work fine
+    # -----------------------------------------------------------------
+    def test_single_manager_returns_correct_membership(self):
+        TenantMembership.objects.create(
+            user=self.multi_user, tenant=self.shop_a, role='manager', is_active=True,
+        )
+        request = _make_request(self.multi_user)
+        tenant, membership = self._get_owner_tenant(request)
+        self.assertIsNotNone(tenant)
+        self.assertEqual(tenant, self.shop_a)
+        self.assertEqual(membership.role, 'manager')
+
+    # -----------------------------------------------------------------
+    # 3. Owner at Shop A + manager at Shop B → must return OWNER (Shop A)
+    #    This is the core regression: alphabetical order would return 'manager'.
+    # -----------------------------------------------------------------
+    def test_owner_beats_manager_in_fallback_branch(self):
+        """CODE-129 core: owner role must win over manager in alphabetical order."""
+        TenantMembership.objects.create(
+            user=self.multi_user, tenant=self.shop_a, role='owner', is_active=True,
+        )
+        TenantMembership.objects.create(
+            user=self.multi_user, tenant=self.shop_b, role='manager', is_active=True,
+        )
+        request = _make_request(self.multi_user)
+        tenant, membership = self._get_owner_tenant(request)
+        self.assertIsNotNone(tenant, "Expected a tenant to be returned")
+        self.assertEqual(membership.role, 'owner',
+            "Expected owner role to win over manager (alphabetical order would "
+            "return 'manager' first — CODE-129 regression)")
+        self.assertEqual(tenant, self.shop_a,
+            "Expected Shop A (where user is owner) not Shop B (where manager)")
+
+    # -----------------------------------------------------------------
+    # 4. Manager at Shop A + owner at Shop B → must return OWNER (Shop B)
+    # -----------------------------------------------------------------
+    def test_owner_beats_manager_regardless_of_insert_order(self):
+        """Owner always wins even when manager membership was inserted first."""
+        TenantMembership.objects.create(
+            user=self.multi_user, tenant=self.shop_a, role='manager', is_active=True,
+        )
+        TenantMembership.objects.create(
+            user=self.multi_user, tenant=self.shop_b, role='owner', is_active=True,
+        )
+        request = _make_request(self.multi_user)
+        tenant, membership = self._get_owner_tenant(request)
+        self.assertIsNotNone(tenant)
+        self.assertEqual(membership.role, 'owner')
+        self.assertEqual(tenant, self.shop_b)
+
+    # -----------------------------------------------------------------
+    # 5. Viewer / technician → (None, None)
+    # -----------------------------------------------------------------
+    def test_viewer_returns_none(self):
+        TenantMembership.objects.create(
+            user=self.multi_user, tenant=self.shop_a, role='viewer', is_active=True,
+        )
+        request = _make_request(self.multi_user)
+        tenant, membership = self._get_owner_tenant(request)
+        self.assertIsNone(tenant)
+        self.assertIsNone(membership)
+
+    def test_technician_returns_none(self):
+        TenantMembership.objects.create(
+            user=self.multi_user, tenant=self.shop_a, role='technician', is_active=True,
+        )
+        request = _make_request(self.multi_user)
+        tenant, membership = self._get_owner_tenant(request)
+        self.assertIsNone(tenant)
+        self.assertIsNone(membership)
+
+    # -----------------------------------------------------------------
+    # 6. Inactive memberships are ignored
+    # -----------------------------------------------------------------
+    def test_inactive_memberships_are_ignored(self):
+        TenantMembership.objects.create(
+            user=self.multi_user, tenant=self.shop_a, role='owner', is_active=False,
+        )
+        TenantMembership.objects.create(
+            user=self.multi_user, tenant=self.shop_b, role='manager', is_active=True,
+        )
+        request = _make_request(self.multi_user)
+        tenant, membership = self._get_owner_tenant(request)
+        # Only the active manager membership should be returned
+        self.assertIsNotNone(tenant)
+        self.assertEqual(membership.role, 'manager')
+        self.assertEqual(tenant, self.shop_b)


### PR DESCRIPTION
## Changes

### CODE-128 — billing_email guard in owner_send_reminder
Fleet customers with billing_email but no customer.email were blocked from receiving manual reminders.

### CODE-129 — _get_owner_tenant() role ordering
Fallback branch used alphabetical .order_by('role') — 'manager' < 'owner' so multi-shop users got wrong shop.

### CODE-130 — Remove hardcoded Arkansas defaults + tax setup step
- State tax rate defaulted to 6.5% (AR rate) across 4 files — now defaults to 0
- State field defaulted to 'AR' in setup wizard — now blank
- Removed 'Configure sales tax' from setup checklist (tax is optional, shouldn't block setup completion)

All targeted tests pass.