### PR TITLE
Fix requirements.txt PyPDF2 line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,5 @@ stripe>=8.0.0
 reportlab>=4.0.0
 
 # Error tracking and monitoring
-sentry-sdk==1.40.0 PyPDF2>=3.0.0
+sentry-sdk==1.40.0
+PyPDF2>=3.0.0


### PR DESCRIPTION
Was appended to same line as sentry-sdk, breaking pip install on EB.