### PR TITLE
v2.8: Mobile UI fixes, S3 cleanup, payment terms override, N+1 fix, Decimal bug

### DIFF
--- a/apps/billing/models.py
+++ b/apps/billing/models.py
@@ -12,12 +12,15 @@ Tracks:
 Author: Amelia (Clawdbot AI)
 """
 
+import logging
 from django.db import models, transaction
 from django.utils import timezone
 from django.core.validators import MinValueValidator, RegexValidator
 from django.core.exceptions import ValidationError
 from decimal import Decimal
 from apps.tenants.managers import TenantManager
+
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -449,7 +452,39 @@ class Invoice(models.Model):
     
     def __str__(self):
         return f"{self.invoice_number} - {self.customer.name} - ${self.total}"
-    
+
+    # ------------------------------------------------------------------
+    # S3 cleanup on delete (CODE-152)
+    # ------------------------------------------------------------------
+    def delete(self, *args, **kwargs):
+        """Delete the invoice and its S3 PDF object (if any).
+
+        Voided (CANCELLED) invoices keep their PDF for audit trail — the S3
+        object is only removed when the record is actually deleted (DRAFT or
+        already-voided invoices).
+        """
+        self._delete_s3_object()
+        super().delete(*args, **kwargs)
+
+    def _delete_s3_object(self):
+        """Remove the S3 object for this invoice's PDF, if one exists."""
+        if not self.s3_key:
+            return
+        try:
+            from django.conf import settings
+            bucket = getattr(settings, 'AWS_STORAGE_BUCKET_NAME', None)
+            if not bucket:
+                return
+            import boto3
+            from botocore.exceptions import ClientError
+            s3_client = boto3.client('s3')
+            s3_client.delete_object(Bucket=bucket, Key=self.s3_key)
+            logger.info(f"Deleted S3 object: s3://{bucket}/{self.s3_key}")
+        except Exception as e:
+            # Log but don't block deletion — orphaned S3 objects are
+            # preferable to a stuck invoice that can't be deleted.
+            logger.warning(f"Failed to delete S3 object {self.s3_key}: {e}")
+
     @property
     def amount_due(self):
         """Amount still owed on this invoice."""

--- a/apps/billing/services/invoice_tracking_service.py
+++ b/apps/billing/services/invoice_tracking_service.py
@@ -47,7 +47,8 @@ class InvoiceTrackingService:
         return self._billing_config
     
     def create_invoice_from_repairs(self, customer, repairs, invoice_number=None, 
-                                     due_days=None, s3_key=None, auto_send=False):
+                                     due_days=None, s3_key=None, auto_send=False,
+                                     payment_terms=None):
         """
         Create a tracked Invoice from a list of repairs.
         
@@ -61,6 +62,8 @@ class InvoiceTrackingService:
                        Callers must mark SENT only after email delivery is confirmed.
                        (See AGENTS.md gotcha: "Don't mark invoices SENT before
                        confirming email delivery")
+            payment_terms: Override payment terms for this invoice (e.g. 'NET30').
+                          If None, uses BillingConfig.default_payment_terms.
             
         Returns:
             Invoice instance
@@ -86,13 +89,27 @@ class InvoiceTrackingService:
         if not invoice_number:
             invoice_number = self._generate_invoice_number(customer)
         
-        # Get payment terms from BillingConfig
-        payment_terms = 'COD'
-        if self.billing_config:
-            payment_terms = self.billing_config.default_payment_terms
-            # Use config-based due days if caller didn't specify
+        # Get payment terms — caller override takes priority over BillingConfig
+        if payment_terms is None:
+            payment_terms = 'COD'
+            if self.billing_config:
+                payment_terms = self.billing_config.default_payment_terms
+                # Use config-based due days if caller didn't specify
+                if due_days is None:
+                    due_days = self.billing_config.due_days_for_terms
+        else:
+            # Caller specified payment_terms — derive due_days from it if not
+            # explicitly provided.  (CODE-153)
             if due_days is None:
-                due_days = self.billing_config.due_days_for_terms
+                terms_days = {
+                    'COD': 0,
+                    'DUE_ON_RECEIPT': 0,
+                    'NET15': 15,
+                    'NET30': 30,
+                    'NET45': 45,
+                    'NET60': 60,
+                }
+                due_days = terms_days.get(payment_terms, 0)
         
         due_days = due_days or 0
         due_date = timezone.now().date() + timedelta(days=due_days) if due_days > 0 else timezone.now().date()

--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -211,11 +211,24 @@ def create_invoice(request, customer_id):
     try:
         due_days = data.get('due_days', 30)
         send_email = data.get('auto_email', False)
+
+        # Optional payment-terms override (CODE-153).  Validate against
+        # the canonical choices list to prevent arbitrary values.
+        from apps.billing.models import BillingConfig
+        req_payment_terms = data.get('payment_terms')  # None = use default
+        valid_terms = {code for code, _label in BillingConfig.PAYMENT_TERMS_CHOICES}
+        if req_payment_terms and req_payment_terms not in valid_terms:
+            return JsonResponse(
+                {'error': f'Invalid payment_terms: {req_payment_terms}'},
+                status=400,
+            )
+
         invoice = tracking.create_invoice_from_repairs(
             customer=customer,
             repairs=repairs,
-            due_days=due_days,
-            auto_send=send_email,  # SENT if emailing, DRAFT otherwise
+            due_days=due_days if req_payment_terms is None else None,
+            auto_send=send_email,
+            payment_terms=req_payment_terms,
         )
         # Ensure invoice is associated with the tenant
         if not invoice.tenant_id:

--- a/apps/customer_portal/pricing_models.py
+++ b/apps/customer_portal/pricing_models.py
@@ -85,19 +85,31 @@ class CustomerPricing(models.Model):
         return f"{self.customer.name} - {status} Pricing"
 
     def get_repair_price(self, repair_count):
-        """Get the price for a repair based on repair count"""
+        """Get the price for a repair based on repair count.
+
+        Returns the custom price for the given tier, or None if the tier has not
+        been configured (field is NULL) — signalling the caller to fall back to
+        default/tenant pricing.
+
+        Important: use ``is not None`` to test whether a tier is configured.
+        ``Decimal('0.00')`` is falsy in Python, so a bare truthiness check like
+        ``if self.repair_1_price:`` would treat an intentional $0 custom price
+        (free service, warranty account, etc.) as "not configured" and silently
+        fall back to the standard rate.  This is the same Decimal-falsy bug
+        documented in AGENTS.md and previously fixed in CODE-132 / CODE-151.
+        """
         if not self.use_custom_pricing:
             return None  # Use default pricing
 
-        if repair_count == 1 and self.repair_1_price:
+        if repair_count == 1 and self.repair_1_price is not None:
             return self.repair_1_price
-        elif repair_count == 2 and self.repair_2_price:
+        elif repair_count == 2 and self.repair_2_price is not None:
             return self.repair_2_price
-        elif repair_count == 3 and self.repair_3_price:
+        elif repair_count == 3 and self.repair_3_price is not None:
             return self.repair_3_price
-        elif repair_count == 4 and self.repair_4_price:
+        elif repair_count == 4 and self.repair_4_price is not None:
             return self.repair_4_price
-        elif repair_count >= 5 and self.repair_5_plus_price:
+        elif repair_count >= 5 and self.repair_5_plus_price is not None:
             return self.repair_5_plus_price
 
         # If specific tier not set, return None to use default

--- a/apps/customer_portal/views.py
+++ b/apps/customer_portal/views.py
@@ -1801,44 +1801,13 @@ def account_settings(request):
             new_password = request.POST.get('new_password', '')
             confirm_password = request.POST.get('confirm_password', '')
             
-            # Validate and save user info
-            if email and email != user.email:
-                if User.objects.filter(email=email).exclude(id=user.id).exists():
-                    messages.error(request, "This email is already in use by another account.")
-                    repair_form = RepairPreferenceForm(instance=repair_prefs)
-                    return render(request, 'customer_portal/account_settings.html', {
-                        'customer_user': customer_user,
-                        'repair_form': repair_form,
-                    })
-                user.email = email
-                # Reset email verification when email changes
-                if customer.email_verified:
-                    messages.info(request, "Email address changed. Please verify your new email address.")
-                customer.email_verified = False
-                customer.email_verified_at = None
-                # Also update notification preferences
-                prefs, created = CustomerNotificationPreference.objects.get_or_create(customer=customer)
-                prefs.email_verified = False
-                prefs.email_verified_at = None
-                prefs.save()
-            
-            user.first_name = first_name
-            user.last_name = last_name
-
-            # Handle phone number update
-            if phone != customer.phone:
-                if customer.phone_verified:
-                    messages.info(request, "Phone number changed. Please verify your new phone number.")
-                customer.phone = phone
-                customer.phone_verified = False
-                customer.phone_verified_at = None
-                # Also update notification preferences
-                prefs, created = CustomerNotificationPreference.objects.get_or_create(customer=customer)
-                prefs.phone_verified = False
-                prefs.phone_verified_at = None
-                prefs.save()
-
-            # Handle password change if provided
+            # --- PASSWORD VALIDATION FIRST ---
+            # Must validate the password change BEFORE mutating and saving any
+            # contact-verification state (prefs.email_verified, prefs.phone_verified).
+            # Previously, prefs.save() was called eagerly inside the email/phone
+            # change blocks, then the password check returned early — leaving
+            # CustomerNotificationPreference.phone_verified=False while
+            # Customer.phone_verified stayed True (desync). (CODE-154)
             if current_password and new_password and confirm_password:
                 if not user.check_password(current_password):
                     messages.error(request, "Current password is incorrect.")
@@ -1863,9 +1832,45 @@ def account_settings(request):
                         'customer_user': customer_user,
                         'repair_form': repair_form,
                     })
-                
+
                 user.set_password(new_password)
                 update_session_auth_hash(request, user)  # Keep user logged in
+
+            # --- VALIDATE AND STAGE all contact/user changes ---
+            # Collect any notification-preference mutations into a pending dict so
+            # we can save them together with customer/user at the very end.
+            # This prevents partial state if a later step raises an exception.
+            prefs_updates = {}  # field → value
+
+            if email and email != user.email:
+                if User.objects.filter(email=email).exclude(id=user.id).exists():
+                    messages.error(request, "This email is already in use by another account.")
+                    repair_form = RepairPreferenceForm(instance=repair_prefs)
+                    return render(request, 'customer_portal/account_settings.html', {
+                        'customer_user': customer_user,
+                        'repair_form': repair_form,
+                    })
+                user.email = email
+                # Reset email verification when email changes
+                if customer.email_verified:
+                    messages.info(request, "Email address changed. Please verify your new email address.")
+                customer.email_verified = False
+                customer.email_verified_at = None
+                prefs_updates['email_verified'] = False
+                prefs_updates['email_verified_at'] = None
+            
+            user.first_name = first_name
+            user.last_name = last_name
+
+            # Handle phone number update
+            if phone != customer.phone:
+                if customer.phone_verified:
+                    messages.info(request, "Phone number changed. Please verify your new phone number.")
+                customer.phone = phone
+                customer.phone_verified = False
+                customer.phone_verified_at = None
+                prefs_updates['phone_verified'] = False
+                prefs_updates['phone_verified_at'] = None
             
             # Update primary contact status.
             # If this user is claiming primary contact, first demote any existing
@@ -1884,7 +1889,16 @@ def account_settings(request):
             try:
                 user.save()
                 customer_user.save()
-                customer.save()  # Save phone changes and verification status
+                customer.save()  # Save phone/email verification status changes
+                # Apply notification-preference verification resets (collected above)
+                # in one update so they are always in sync with the Customer row.
+                if prefs_updates:
+                    prefs_obj, _ = CustomerNotificationPreference.objects.get_or_create(
+                        customer=customer
+                    )
+                    for field, value in prefs_updates.items():
+                        setattr(prefs_obj, field, value)
+                    prefs_obj.save(update_fields=list(prefs_updates.keys()))
                 messages.success(request, "Account settings updated successfully!")
                 return redirect('customer_dashboard')
             except Exception as e:

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -2314,6 +2314,17 @@ def owner_invoice_list(request):
                 'total': info['total'],
             })
 
+    # Default payment terms for invoice creation modal (CODE-153)
+    from apps.billing.models import BillingConfig
+    try:
+        billing_config = BillingConfig.get_for_tenant(tenant)
+        default_payment_terms = billing_config.default_payment_terms
+    except Exception:
+        default_payment_terms = 'COD'
+    terms_display = dict(BillingConfig.PAYMENT_TERMS_CHOICES).get(
+        default_payment_terms, default_payment_terms
+    )
+
     context = {
         'tenant': tenant,
         'invoices': invoices,
@@ -2326,6 +2337,8 @@ def owner_invoice_list(request):
         'payments_month_amount': payments_month_amount,
         'invoices_this_month': invoices_this_month,
         'uninvoiced_customers': uninvoiced_customers,
+        'default_payment_terms': default_payment_terms,
+        'default_payment_terms_display': terms_display,
     }
     return render(request, 'saas/owner_invoices.html', context)
 
@@ -3722,9 +3735,12 @@ def owner_invoice_bulk_action(request):
         deleted_count = safe_to_delete.count()
         skipped_active = invoices.exclude(status__in=['DRAFT', 'CANCELLED']).count()
 
-        # Perform the delete inside a try/except as a last-resort safety net.
+        # Perform the delete via instance loop so Invoice.delete() fires
+        # (which cleans up S3 objects).  QuerySet.delete() bypasses model
+        # overrides — see AGENTS.md gotcha.  (CODE-152)
         try:
-            safe_to_delete.delete()
+            for inv in safe_to_delete:
+                inv.delete()
         except _ProtectedError:
             return JsonResponse(
                 {'success': False, 'error': 'Delete failed: one or more invoices have payment records.'},
@@ -3878,13 +3894,21 @@ def owner_generate_invoice_from_repair(request, repair_id):
         ).select_related('invoice').first()
         return redirect('owner_invoice_detail', invoice_id=line_item.invoice_id)
 
-    # Generate the invoice
+    # Generate the invoice — accept optional payment_terms override (CODE-153)
+    req_payment_terms = request.POST.get('payment_terms') or None
+    if req_payment_terms:
+        from apps.billing.models import BillingConfig
+        valid_terms = {code for code, _label in BillingConfig.PAYMENT_TERMS_CHOICES}
+        if req_payment_terms not in valid_terms:
+            req_payment_terms = None  # fall back to default
+
     try:
         from apps.billing.services.invoice_tracking_service import InvoiceTrackingService
         tracking_svc = InvoiceTrackingService(tenant=tenant)
         invoice = tracking_svc.create_invoice_from_repairs(
             customer=repair.customer,
             repairs=[repair],
+            payment_terms=req_payment_terms,
         )
         messages.success(request, f'Invoice {invoice.invoice_number} created as draft. Review and send below.')
         return redirect('owner_invoice_detail', invoice_id=invoice.id)

--- a/apps/technician_portal/services/pricing_service.py
+++ b/apps/technician_portal/services/pricing_service.py
@@ -35,19 +35,32 @@ def get_tenant_repair_price(tenant, repair_count: int) -> Decimal:
 
     Returns:
         Decimal: The repair cost based on tenant configuration
+
+    Note: Tenant repair_price fields are non-nullable DecimalFields with a
+    positive default, so they are never None.  However we must NOT use a bare
+    truthiness check (``tenant.repair_price_1 or DEFAULT_PRICING[1]``) because
+    ``Decimal('0.00')`` is falsy — a tenant that deliberately sets a $0 price
+    tier (e.g. for free-service or warranty accounts) would silently receive
+    the $50 system default instead.  Checking ``is not None`` is the correct
+    pattern (documented in AGENTS.md: "Decimal('0.00') is falsy in Python").
     """
     if tenant:
         if repair_count == 1:
-            return tenant.repair_price_1 or DEFAULT_PRICING[1]
+            val = tenant.repair_price_1
+            return val if val is not None else DEFAULT_PRICING[1]
         elif repair_count == 2:
-            return tenant.repair_price_2 or DEFAULT_PRICING[2]
+            val = tenant.repair_price_2
+            return val if val is not None else DEFAULT_PRICING[2]
         elif repair_count == 3:
-            return tenant.repair_price_3 or DEFAULT_PRICING[3]
+            val = tenant.repair_price_3
+            return val if val is not None else DEFAULT_PRICING[3]
         elif repair_count == 4:
-            return tenant.repair_price_4 or DEFAULT_PRICING[4]
+            val = tenant.repair_price_4
+            return val if val is not None else DEFAULT_PRICING[4]
         else:
-            return tenant.repair_price_5_plus or DEFAULT_PRICE_5_PLUS
-    
+            val = tenant.repair_price_5_plus
+            return val if val is not None else DEFAULT_PRICE_5_PLUS
+
     return DEFAULT_PRICING.get(repair_count, DEFAULT_PRICE_5_PLUS)
 
 

--- a/apps/technician_portal/views/repairs.py
+++ b/apps/technician_portal/views/repairs.py
@@ -6,7 +6,7 @@ from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib import messages
 from django.utils import timezone
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Q, Count
 from django.http import JsonResponse
 from django.core.paginator import Paginator
 from decimal import Decimal, InvalidOperation
@@ -119,16 +119,28 @@ def repair_list(request):
             managed_tech_ids = list(technician.managed_technicians.values_list('id', flat=True))
             repairs = repairs.filter(technician_id__in=managed_tech_ids)
 
-    # Summary statistics
-    total_repairs = repairs.count()
+    # Summary statistics — computed in one aggregate query instead of 5 separate
+    # COUNT queries.  This is the same N+1 fix applied to customer_dashboard (CODE-141)
+    # and customer_repairs (CODE-143), now applied to the technician repair list.
+    # Each conditional Count(filter=Q(...)) becomes a CASE WHEN in a single SQL
+    # SELECT, eliminating 4 extra DB round-trips per page load.  (CODE-151)
+    _week_start = timezone.now().date() - timezone.timedelta(days=7)
+    _stats_agg = repairs.aggregate(
+        total_count=Count('id'),
+        total_active=Count('id', filter=~Q(queue_status='COMPLETED')),
+        pending_approval=Count('id', filter=Q(queue_status='REQUESTED')),
+        in_progress=Count('id', filter=Q(queue_status='IN_PROGRESS')),
+        completed_this_week=Count(
+            'id',
+            filter=Q(queue_status='COMPLETED', service_date__gte=_week_start),
+        ),
+    )
+    total_repairs = _stats_agg['total_count']
     stats = {
-        'total_active': repairs.exclude(queue_status='COMPLETED').count(),
-        'pending_approval': repairs.filter(queue_status='REQUESTED').count(),
-        'in_progress': repairs.filter(queue_status='IN_PROGRESS').count(),
-        'completed_this_week': repairs.filter(
-            queue_status='COMPLETED',
-            service_date__gte=timezone.now().date() - timezone.timedelta(days=7)
-        ).count()
+        'total_active': _stats_agg['total_active'],
+        'pending_approval': _stats_agg['pending_approval'],
+        'in_progress': _stats_agg['in_progress'],
+        'completed_this_week': _stats_agg['completed_this_week'],
     }
 
     # Sorting

--- a/apps/technician_portal/views/repairs.py
+++ b/apps/technician_portal/views/repairs.py
@@ -292,6 +292,16 @@ def repair_detail(request, repair_id):
             is_invoiced = True
             invoice_id = line_item.invoice_id
 
+    # Default payment terms for generate-invoice dropdown (CODE-153)
+    default_payment_terms = 'COD'
+    if tenant:
+        try:
+            from apps.billing.models import BillingConfig
+            bc = BillingConfig.get_for_tenant(tenant)
+            default_payment_terms = bc.default_payment_terms
+        except Exception:
+            pass
+
     return render(request, 'technician_portal/repair_detail.html', {
         'repair': repair,
         'TIME_ZONE': timezone.get_current_timezone_name(),
@@ -304,6 +314,7 @@ def repair_detail(request, repair_id):
         'next_break': next_break,
         'is_invoiced': is_invoiced,
         'invoice_id': invoice_id,
+        'default_payment_terms': default_payment_terms,
     })
 
 

--- a/templates/saas/owner_invoice_detail.html
+++ b/templates/saas/owner_invoice_detail.html
@@ -12,45 +12,45 @@
         <span class="text-gray-400">/</span>
         <span class="text-gray-600">{{ invoice.invoice_number }}</span>
     </div>
-    <div class="flex items-center gap-2 flex-wrap">
+    <div class="flex items-center gap-1.5 sm:gap-2 flex-wrap">
         {% if invoice.status == 'DRAFT' %}
         <!-- Draft Actions -->
         <button onclick="document.getElementById('send-confirm-modal').classList.remove('hidden')"
-            class="inline-flex items-center px-4 py-2 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors">
-            <i class="fas fa-paper-plane mr-2"></i>Send Invoice
+            class="inline-flex items-center px-3 sm:px-4 py-2 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors">
+            <i class="fas fa-paper-plane sm:mr-2"></i><span class="hidden sm:inline">Send Invoice</span>
         </button>
         {% if pdf_url %}
-        <a href="{{ pdf_url }}" target="_blank" class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
-            <i class="fas fa-download mr-2"></i>Download PDF
+        <a href="{{ pdf_url }}" target="_blank" class="inline-flex items-center px-2.5 sm:px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
+            <i class="fas fa-download sm:mr-2"></i><span class="hidden sm:inline">Download PDF</span>
         </a>
         {% endif %}
-        <a href="{% url 'owner_invoice_pdf' invoice_id=invoice.id %}" target="_blank" class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
-            <i class="fas fa-file-pdf mr-2"></i>{% if pdf_url %}Regenerate{% else %}Generate{% endif %} PDF
+        <a href="{% url 'owner_invoice_pdf' invoice_id=invoice.id %}" target="_blank" class="inline-flex items-center px-2.5 sm:px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
+            <i class="fas fa-file-pdf sm:mr-2"></i><span class="hidden sm:inline">{% if pdf_url %}Regenerate{% else %}Generate{% endif %} PDF</span>
         </a>
         {% else %}
         <!-- Sent/Active Invoice Actions -->
         {% if pdf_url %}
-        <a href="{{ pdf_url }}" target="_blank" class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
-            <i class="fas fa-download mr-2"></i>Download PDF
+        <a href="{{ pdf_url }}" target="_blank" class="inline-flex items-center px-2.5 sm:px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
+            <i class="fas fa-download sm:mr-2"></i><span class="hidden sm:inline">Download PDF</span>
         </a>
         {% endif %}
-        <a href="{% url 'owner_invoice_pdf' invoice_id=invoice.id %}" target="_blank" class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
-            <i class="fas fa-file-pdf mr-2"></i>{% if pdf_url %}Regenerate{% else %}Generate{% endif %} PDF
+        <a href="{% url 'owner_invoice_pdf' invoice_id=invoice.id %}" target="_blank" class="inline-flex items-center px-2.5 sm:px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
+            <i class="fas fa-file-pdf sm:mr-2"></i><span class="hidden sm:inline">{% if pdf_url %}Regenerate{% else %}Generate{% endif %} PDF</span>
         </a>
         <form method="post" action="{% url 'owner_email_invoice' invoice_id=invoice.id %}" class="inline">
             {% csrf_token %}
-            <button type="submit" class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
-                <i class="fas fa-envelope mr-2"></i>Email Invoice
+            <button type="submit" class="inline-flex items-center px-2.5 sm:px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
+                <i class="fas fa-envelope sm:mr-2"></i><span class="hidden sm:inline">Email Invoice</span>
             </button>
         </form>
         {% if invoice.status != 'PAID' and invoice.status != 'CANCELLED' and invoice.status != 'DRAFT' %}
-        <button onclick="openReminderModal()" class="inline-flex items-center px-3 py-2 text-sm font-medium text-amber-700 bg-amber-50 border border-amber-300 rounded-lg hover:bg-amber-100 transition-colors">
-            <i class="fas fa-bell mr-2"></i>Send Reminder
+        <button onclick="openReminderModal()" class="inline-flex items-center px-2.5 sm:px-3 py-2 text-sm font-medium text-amber-700 bg-amber-50 border border-amber-300 rounded-lg hover:bg-amber-100 transition-colors">
+            <i class="fas fa-bell sm:mr-2"></i><span class="hidden sm:inline">Send Reminder</span>
         </button>
         {% endif %}
         {% if invoice.status != 'PAID' and invoice.status != 'CANCELLED' %}
-        <button onclick="voidInvoice()" class="inline-flex items-center px-3 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-300 rounded-lg hover:bg-red-100 transition-colors">
-            <i class="fas fa-ban mr-2"></i>Void Invoice
+        <button onclick="voidInvoice()" class="inline-flex items-center px-2.5 sm:px-3 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-300 rounded-lg hover:bg-red-100 transition-colors">
+            <i class="fas fa-ban sm:mr-2"></i><span class="hidden sm:inline">Void Invoice</span>
         </button>
         {% endif %}
         {% endif %}

--- a/templates/saas/owner_invoices.html
+++ b/templates/saas/owner_invoices.html
@@ -126,27 +126,29 @@
     </div>
     <div class="divide-y divide-gray-100">
         {% for item in uninvoiced_customers %}
-        <div class="px-6 py-3 flex items-center justify-between hover:bg-gray-50">
-            <div class="flex items-center gap-3">
-                <div class="w-8 h-8 rounded-full bg-indigo-100 flex items-center justify-center">
-                    <i class="fas fa-truck text-indigo-600 text-xs"></i>
+        <div class="px-4 sm:px-6 py-3 hover:bg-gray-50">
+            <div class="flex items-center justify-between gap-2">
+                <div class="flex items-center gap-3 min-w-0">
+                    <div class="w-8 h-8 rounded-full bg-indigo-100 flex items-center justify-center flex-shrink-0">
+                        <i class="fas fa-truck text-indigo-600 text-xs"></i>
+                    </div>
+                    <div class="min-w-0">
+                        <span class="text-sm font-medium text-gray-900 capitalize truncate block">{{ item.customer.name }}</span>
+                        <span class="text-xs text-gray-500">{{ item.count }} repair{{ item.count|pluralize }} · ${{ item.total|floatformat:2 }}</span>
+                    </div>
                 </div>
-                <div>
-                    <span class="text-sm font-medium text-gray-900 capitalize">{{ item.customer.name }}</span>
-                    <span class="text-xs text-gray-500 ml-2">{{ item.count }} repair{{ item.count|pluralize }}</span>
+                <div class="flex items-center gap-1.5 sm:gap-2 flex-shrink-0">
+                    <span class="text-sm font-semibold text-gray-900 hidden sm:inline">${{ item.total|floatformat:2 }}</span>
+                    <button onclick="openInvoiceModal({{ item.customer.id }}, '{{ item.customer.name|escapejs }}')"
+                        class="inline-flex items-center px-2 sm:px-3 py-1.5 bg-blue-600 text-white text-xs font-medium rounded-lg hover:bg-blue-700 transition-colors">
+                        <i class="fas fa-file-invoice sm:mr-1.5"></i><span class="hidden sm:inline">Create Invoice</span>
+                    </button>
+                    <button onclick="dismissUninvoiced({{ item.customer.id }}, '{{ item.customer.name|escapejs }}')"
+                        class="inline-flex items-center px-2 sm:px-3 py-1.5 bg-gray-100 text-gray-600 text-xs font-medium rounded-lg hover:bg-gray-200 transition-colors"
+                        title="Already paid outside system? Dismiss these repairs.">
+                        <i class="fas fa-times sm:mr-1.5"></i><span class="hidden sm:inline">Dismiss</span>
+                    </button>
                 </div>
-            </div>
-            <div class="flex items-center gap-2 sm:gap-4">
-                <span class="text-sm font-semibold text-gray-900">${{ item.total|floatformat:2 }}</span>
-                <button onclick="openInvoiceModal({{ item.customer.id }}, '{{ item.customer.name|escapejs }}')"
-                    class="inline-flex items-center px-3 py-1.5 bg-blue-600 text-white text-xs font-medium rounded-lg hover:bg-blue-700 transition-colors">
-                    <i class="fas fa-file-invoice mr-1.5"></i>Create Invoice
-                </button>
-                <button onclick="dismissUninvoiced({{ item.customer.id }}, '{{ item.customer.name|escapejs }}')"
-                    class="inline-flex items-center px-3 py-1.5 bg-gray-100 text-gray-600 text-xs font-medium rounded-lg hover:bg-gray-200 transition-colors"
-                    title="Already paid outside system? Dismiss these repairs.">
-                    <i class="fas fa-times mr-1.5"></i>Dismiss
-                </button>
             </div>
         </div>
         {% endfor %}
@@ -155,26 +157,31 @@
 {% endif %}
 
 <!-- Batch Actions Bar (hidden until checkboxes selected) -->
-<div id="batch-bar" class="hidden sticky top-16 z-10 bg-blue-600 text-white rounded-xl shadow-lg p-3 mb-4 flex items-center justify-between">
-    <div class="flex items-center gap-3">
-        <span class="text-sm font-medium"><span id="selected-count">0</span> invoice(s) selected</span>
-    </div>
-    <div class="flex items-center gap-2">
-        <button onclick="sendSelectedEmails()" class="inline-flex items-center px-4 py-1.5 bg-white text-blue-700 text-sm font-medium rounded-lg hover:bg-blue-50 transition-colors">
-            <i class="fas fa-envelope mr-1.5"></i>Send Email
-        </button>
-        <button onclick="markSelectedPaid()" class="inline-flex items-center px-4 py-1.5 bg-green-500 text-white text-sm font-medium rounded-lg hover:bg-green-600 transition-colors">
-            <i class="fas fa-check-circle mr-1.5"></i>Mark Paid
-        </button>
-        <button onclick="voidSelectedInvoices()" class="inline-flex items-center px-4 py-1.5 bg-yellow-500 text-white text-sm font-medium rounded-lg hover:bg-yellow-600 transition-colors">
-            <i class="fas fa-ban mr-1.5"></i>Void
-        </button>
-        <button onclick="deleteSelectedInvoices()" class="inline-flex items-center px-4 py-1.5 bg-red-500 text-white text-sm font-medium rounded-lg hover:bg-red-600 transition-colors">
-            <i class="fas fa-trash mr-1.5"></i>Delete
-        </button>
-        <button onclick="clearSelection()" class="inline-flex items-center px-3 py-1.5 text-blue-200 text-sm hover:text-white transition-colors">
-            <i class="fas fa-times mr-1"></i>Clear
-        </button>
+<div id="batch-bar" class="hidden sticky top-16 z-10 bg-blue-600 text-white rounded-xl shadow-lg p-3 mb-4">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+        <div class="flex items-center gap-3">
+            <span class="text-sm font-medium"><span id="selected-count">0</span> selected</span>
+            <button onclick="clearSelection()" class="inline-flex items-center text-blue-200 text-sm hover:text-white transition-colors sm:hidden">
+                <i class="fas fa-times mr-1"></i>Clear
+            </button>
+        </div>
+        <div class="flex items-center gap-1.5 sm:gap-2 flex-wrap">
+            <button onclick="sendSelectedEmails()" class="inline-flex items-center px-2.5 sm:px-4 py-1.5 bg-white text-blue-700 text-xs sm:text-sm font-medium rounded-lg hover:bg-blue-50 transition-colors">
+                <i class="fas fa-envelope sm:mr-1.5"></i><span class="hidden sm:inline ml-1">Send Email</span>
+            </button>
+            <button onclick="markSelectedPaid()" class="inline-flex items-center px-2.5 sm:px-4 py-1.5 bg-green-500 text-white text-xs sm:text-sm font-medium rounded-lg hover:bg-green-600 transition-colors">
+                <i class="fas fa-check-circle sm:mr-1.5"></i><span class="hidden sm:inline ml-1">Mark Paid</span>
+            </button>
+            <button onclick="voidSelectedInvoices()" class="inline-flex items-center px-2.5 sm:px-4 py-1.5 bg-yellow-500 text-white text-xs sm:text-sm font-medium rounded-lg hover:bg-yellow-600 transition-colors">
+                <i class="fas fa-ban sm:mr-1.5"></i><span class="hidden sm:inline ml-1">Void</span>
+            </button>
+            <button onclick="deleteSelectedInvoices()" class="inline-flex items-center px-2.5 sm:px-4 py-1.5 bg-red-500 text-white text-xs sm:text-sm font-medium rounded-lg hover:bg-red-600 transition-colors">
+                <i class="fas fa-trash sm:mr-1.5"></i><span class="hidden sm:inline ml-1">Delete</span>
+            </button>
+            <button onclick="clearSelection()" class="hidden sm:inline-flex items-center px-3 py-1.5 text-blue-200 text-sm hover:text-white transition-colors">
+                <i class="fas fa-times mr-1"></i>Clear
+            </button>
+        </div>
     </div>
 </div>
 

--- a/templates/saas/owner_invoices.html
+++ b/templates/saas/owner_invoices.html
@@ -399,6 +399,20 @@
                     <span class="text-sm text-gray-600">Selected Total:</span>
                     <span class="text-lg font-bold text-gray-900">$<span id="modal-total">0.00</span></span>
                 </div>
+
+                <!-- Payment Terms Override (CODE-153) -->
+                <div class="px-6 py-3 border-t border-gray-100">
+                    <label for="modal-payment-terms" class="block text-sm font-medium text-gray-700 mb-1">Payment Terms</label>
+                    <select id="modal-payment-terms" class="w-full rounded-lg border-gray-300 text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <option value="COD"{% if default_payment_terms == 'COD' %} selected{% endif %}>Cash on Delivery (COD)</option>
+                        <option value="DUE_ON_RECEIPT"{% if default_payment_terms == 'DUE_ON_RECEIPT' %} selected{% endif %}>Due on Receipt</option>
+                        <option value="NET15"{% if default_payment_terms == 'NET15' %} selected{% endif %}>Net 15</option>
+                        <option value="NET30"{% if default_payment_terms == 'NET30' %} selected{% endif %}>Net 30</option>
+                        <option value="NET45"{% if default_payment_terms == 'NET45' %} selected{% endif %}>Net 45</option>
+                        <option value="NET60"{% if default_payment_terms == 'NET60' %} selected{% endif %}>Net 60</option>
+                    </select>
+                    <p class="text-xs text-gray-400 mt-1">Default: {{ default_payment_terms_display }}. Change for this invoice only.</p>
+                </div>
             </div>
 
             <!-- Empty state -->
@@ -594,11 +608,12 @@ function createInvoiceAndSend() {
 function submitInvoice(repairIds, sendEmail) {
     const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
         document.cookie.split(';').find(c => c.trim().startsWith('csrftoken='))?.split('=')[1];
+    const paymentTerms = document.getElementById('modal-payment-terms')?.value || null;
 
     fetch(`/api/billing/invoices/create/${modalCustomerId}/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
-        body: JSON.stringify({ repair_ids: repairIds, auto_email: sendEmail }),
+        body: JSON.stringify({ repair_ids: repairIds, auto_email: sendEmail, payment_terms: paymentTerms }),
     })
     .then(r => r.json())
     .then(data => {
@@ -884,10 +899,12 @@ function submitInvoiceForSend(repairIds) {
     btnSend.innerHTML = '<i class="fas fa-spinner fa-spin mr-1.5"></i>Creating...';
     btnSend.disabled = true;
 
+    const paymentTerms = document.getElementById('modal-payment-terms')?.value || null;
+
     fetch(`/api/billing/invoices/create/${modalCustomerId}/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
-        body: JSON.stringify({ repair_ids: repairIds, auto_email: false }),
+        body: JSON.stringify({ repair_ids: repairIds, auto_email: false, payment_terms: paymentTerms }),
     })
     .then(r => r.json())
     .then(data => {

--- a/templates/technician_portal/repair_detail.html
+++ b/templates/technician_portal/repair_detail.html
@@ -118,8 +118,16 @@
                                     <i class="fas fa-file-invoice-dollar mr-2"></i>View Invoice
                                 </a>
                                 {% else %}
-                                <form action="{% url 'owner_generate_invoice_from_repair' repair.id %}" method="post" class="inline">
+                                <form action="{% url 'owner_generate_invoice_from_repair' repair.id %}" method="post" class="inline flex items-center gap-2">
                                     {% csrf_token %}
+                                    <select name="payment_terms" class="rounded-lg border-gray-300 text-sm py-2.5 focus:ring-blue-500 focus:border-blue-500" title="Payment terms for this invoice">
+                                        <option value="COD"{% if default_payment_terms == 'COD' %} selected{% endif %}>COD</option>
+                                        <option value="DUE_ON_RECEIPT"{% if default_payment_terms == 'DUE_ON_RECEIPT' %} selected{% endif %}>Due on Receipt</option>
+                                        <option value="NET15"{% if default_payment_terms == 'NET15' %} selected{% endif %}>Net 15</option>
+                                        <option value="NET30"{% if default_payment_terms == 'NET30' %} selected{% endif %}>Net 30</option>
+                                        <option value="NET45"{% if default_payment_terms == 'NET45' %} selected{% endif %}>Net 45</option>
+                                        <option value="NET60"{% if default_payment_terms == 'NET60' %} selected{% endif %}>Net 60</option>
+                                    </select>
                                     <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-blue-600 text-white text-sm font-bold rounded-lg hover:bg-blue-700 transition-colors shadow-sm">
                                         <i class="fas fa-file-invoice-dollar mr-2"></i>Generate Invoice
                                     </button>

--- a/tests/bug_fixes/test_code151_technician_repair_list_stats_n_plus_one.py
+++ b/tests/bug_fixes/test_code151_technician_repair_list_stats_n_plus_one.py
@@ -1,0 +1,169 @@
+"""
+CODE-151: Regression test — repair_list() stats aggregation (technician portal).
+
+Bug: repair_list() in apps/technician_portal/views/repairs.py fired 5 separate
+DB queries to build the stats dict:
+  1. repairs.count()                                      → total_repairs
+  2. repairs.exclude(queue_status='COMPLETED').count()    → total_active
+  3. repairs.filter(queue_status='REQUESTED').count()     → pending_approval
+  4. repairs.filter(queue_status='IN_PROGRESS').count()   → in_progress
+  5. repairs.filter(...).count()                          → completed_this_week
+
+This is the same N+1 pattern fixed for customer_dashboard (CODE-141) and
+customer_repairs (CODE-143), but was missed in the technician portal repair list.
+
+Fix: collapsed all 5 into a single aggregate() call with conditional Count
+using Django's Q() filter argument. Eliminates 4 round-trips per page load.
+
+Tests verify:
+1. Repair list returns 200 OK with correct stats in context.
+2. total_active, pending_approval, in_progress, completed_this_week are correct.
+3. Stats update correctly as repairs change status.
+4. Completed-this-week only counts repairs from the last 7 days.
+5. Filters applied to the queryset before stats are correctly reflected.
+"""
+
+from datetime import timedelta
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from core.models import Customer
+from apps.tenants.models import Tenant, TenantMembership
+from apps.technician_portal.models import Technician, Repair
+
+
+class TechnicianRepairListStatsAggregationTest(TestCase):
+    """Tests for the consolidated stats in repair_list()."""
+
+    def setUp(self):
+        self.owner_user = User.objects.create_user(
+            username='owner_code151', email='owner151@test.com', password='pass'
+        )
+        self.tenant = Tenant.objects.create(
+            name='Test Shop 151',
+            slug='test-shop-code151',
+            subdomain='test-shop-code151',
+            plan='trial',
+            owner=self.owner_user,
+        )
+        TenantMembership.objects.create(
+            user=self.owner_user,
+            tenant=self.tenant,
+            role='owner',
+            is_active=True,
+        )
+        self.technician = Technician.objects.create(
+            user=self.owner_user,
+            tenant=self.tenant,
+            is_active=True,
+        )
+        self.customer = Customer.objects.create(
+            tenant=self.tenant,
+            name='Fleet Co 151',
+            email='fleet151@test.com',
+            customer_type='FLEET',
+        )
+        self.client = Client()
+        self.client.login(username='owner_code151', password='pass')
+        # Simulate tenant middleware
+        session = self.client.session
+        session['tenant_id'] = self.tenant.id
+        session.save()
+
+    def _make_repair(self, status, days_ago=0):
+        """Helper to create a Repair with given status and service_date."""
+        svc_date = timezone.now() - timedelta(days=days_ago)
+        return Repair.objects.create(
+            technician=self.technician,
+            customer=self.customer,
+            tenant=self.tenant,
+            unit_number=f'UNIT-{status}-{days_ago}',
+            damage_type='Chip',
+            queue_status=status,
+            service_date=svc_date,
+            cost=50,
+        )
+
+    def _get_stats(self):
+        """Make a GET to repair_list and return the stats context dict."""
+        response = self.client.get(
+            '/tech/repairs/',
+            HTTP_HOST=f'{self.tenant.subdomain}.rssystems.io',
+        )
+        return response, response.context.get('stats', {})
+
+    def test_repair_list_returns_200(self):
+        """repair_list() should return 200 OK for an admin user."""
+        response, _ = self._get_stats()
+        self.assertEqual(response.status_code, 200)
+
+    def test_stats_empty_with_no_repairs(self):
+        """All stat counters should be 0 when there are no repairs."""
+        _, stats = self._get_stats()
+        self.assertEqual(stats['total_active'], 0)
+        self.assertEqual(stats['pending_approval'], 0)
+        self.assertEqual(stats['in_progress'], 0)
+        self.assertEqual(stats['completed_this_week'], 0)
+
+    def test_total_active_excludes_completed(self):
+        """total_active counts all non-COMPLETED repairs."""
+        self._make_repair('APPROVED')
+        self._make_repair('IN_PROGRESS')
+        self._make_repair('COMPLETED')
+        self._make_repair('REQUESTED')
+        _, stats = self._get_stats()
+        # APPROVED + IN_PROGRESS + REQUESTED = 3 active
+        self.assertEqual(stats['total_active'], 3)
+
+    def test_pending_approval_counts_requested(self):
+        """pending_approval counts only REQUESTED repairs."""
+        self._make_repair('REQUESTED')
+        self._make_repair('REQUESTED')
+        self._make_repair('APPROVED')
+        _, stats = self._get_stats()
+        self.assertEqual(stats['pending_approval'], 2)
+
+    def test_in_progress_counts_in_progress(self):
+        """in_progress counts only IN_PROGRESS repairs."""
+        self._make_repair('IN_PROGRESS')
+        self._make_repair('IN_PROGRESS')
+        self._make_repair('APPROVED')
+        _, stats = self._get_stats()
+        self.assertEqual(stats['in_progress'], 2)
+
+    def test_completed_this_week_counts_recent_completed(self):
+        """completed_this_week counts COMPLETED repairs from the last 7 days."""
+        self._make_repair('COMPLETED', days_ago=0)   # today — should count
+        self._make_repair('COMPLETED', days_ago=6)   # 6 days ago — should count
+        self._make_repair('COMPLETED', days_ago=8)   # 8 days ago — should NOT count
+        _, stats = self._get_stats()
+        self.assertEqual(stats['completed_this_week'], 2)
+
+    def test_completed_outside_week_not_counted(self):
+        """Repairs completed more than 7 days ago must not appear in completed_this_week."""
+        self._make_repair('COMPLETED', days_ago=10)
+        self._make_repair('COMPLETED', days_ago=30)
+        _, stats = self._get_stats()
+        self.assertEqual(stats['completed_this_week'], 0)
+
+    def test_all_stats_correct_together(self):
+        """All four stats are correct when repairs in multiple statuses exist."""
+        self._make_repair('REQUESTED')          # active + pending
+        self._make_repair('IN_PROGRESS')        # active + in_progress
+        self._make_repair('APPROVED')           # active only
+        self._make_repair('COMPLETED', days_ago=2)   # completed this week
+        self._make_repair('COMPLETED', days_ago=20)  # completed, not this week
+        _, stats = self._get_stats()
+        self.assertEqual(stats['total_active'], 3)
+        self.assertEqual(stats['pending_approval'], 1)
+        self.assertEqual(stats['in_progress'], 1)
+        self.assertEqual(stats['completed_this_week'], 1)
+
+    def test_total_repairs_matches_sum(self):
+        """total_repairs in context matches the actual number of repairs."""
+        self._make_repair('APPROVED')
+        self._make_repair('COMPLETED')
+        self._make_repair('REQUESTED')
+        response, _ = self._get_stats()
+        self.assertEqual(response.context.get('total_repairs'), 3)

--- a/tests/bug_fixes/test_code151_technician_repair_list_stats_n_plus_one.py
+++ b/tests/bug_fixes/test_code151_technician_repair_list_stats_n_plus_one.py
@@ -16,15 +16,17 @@ Fix: collapsed all 5 into a single aggregate() call with conditional Count
 using Django's Q() filter argument. Eliminates 4 round-trips per page load.
 
 Tests verify:
-1. Repair list returns 200 OK with correct stats in context.
+1. repair_list() returns 200 OK with correct stats in context.
 2. total_active, pending_approval, in_progress, completed_this_week are correct.
 3. Stats update correctly as repairs change status.
-4. Completed-this-week only counts repairs from the last 7 days.
-5. Filters applied to the queryset before stats are correctly reflected.
+4. completed_this_week only counts repairs from the last 7 days.
+5. All four stats are correct simultaneously.
 """
 
+import uuid
 from datetime import timedelta
-from django.test import TestCase, Client
+
+from django.test import TestCase, Client, override_settings
 from django.contrib.auth.models import User
 from django.utils import timezone
 
@@ -33,78 +35,104 @@ from apps.tenants.models import Tenant, TenantMembership
 from apps.technician_portal.models import Technician, Repair
 
 
+TEST_OVERRIDES = {
+    'ALLOWED_HOSTS': ['*'],
+    'SESSION_ENGINE': 'django.contrib.sessions.backends.db',
+    'MESSAGE_STORAGE': 'django.contrib.messages.storage.fallback.FallbackStorage',
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_user(username):
+    return User.objects.create_user(
+        username=username, email=f'{username}@example.com', password='testpass'
+    )
+
+
+def _make_tenant(name):
+    slug = uuid.uuid4().hex[:12]
+    owner = _make_user(f'owner_{slug}')
+    tenant = Tenant.objects.create(name=name, slug=slug, subdomain=slug, owner=owner)
+    TenantMembership.objects.create(user=owner, tenant=tenant, role='owner', is_active=True)
+    return tenant, owner
+
+
+def _make_tech(user, tenant, is_manager=False):
+    return Technician.objects.create(
+        user=user, tenant=tenant, is_active=True, is_manager=is_manager,
+    )
+
+
+def _make_membership(user, tenant, role='technician'):
+    TenantMembership.objects.create(user=user, tenant=tenant, role=role, is_active=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@override_settings(**TEST_OVERRIDES)
 class TechnicianRepairListStatsAggregationTest(TestCase):
     """Tests for the consolidated stats in repair_list()."""
 
     def setUp(self):
-        self.owner_user = User.objects.create_user(
-            username='owner_code151', email='owner151@test.com', password='pass'
-        )
-        self.tenant = Tenant.objects.create(
-            name='Test Shop 151',
-            slug='test-shop-code151',
-            subdomain='test-shop-code151',
-            plan='trial',
-            owner=self.owner_user,
-        )
-        TenantMembership.objects.create(
-            user=self.owner_user,
-            tenant=self.tenant,
-            role='owner',
-            is_active=True,
-        )
-        self.technician = Technician.objects.create(
-            user=self.owner_user,
-            tenant=self.tenant,
-            is_active=True,
-        )
+        self.tenant, self.owner = _make_tenant('Stat Shop 151')
+        self.user = _make_user('tech_151')
+        _make_membership(self.user, self.tenant, role='technician')
+        self.tech = _make_tech(self.user, self.tenant, is_manager=True)
         self.customer = Customer.objects.create(
-            tenant=self.tenant,
-            name='Fleet Co 151',
-            email='fleet151@test.com',
-            customer_type='FLEET',
+            tenant=self.tenant, name='Fleet 151', email='fleet151@test.com',
         )
+
         self.client = Client()
-        self.client.login(username='owner_code151', password='pass')
-        # Simulate tenant middleware
         session = self.client.session
         session['tenant_id'] = self.tenant.id
         session.save()
+        self.client.force_login(self.user)
+
+    def _get(self):
+        """Make GET to repair_list and return response."""
+        return self.client.get(
+            '/tech/repairs/',
+            HTTP_HOST='testserver',
+            SERVER_NAME='testserver',
+        )
+
+    def _get_stats(self):
+        """Return (response, stats_dict)."""
+        response = self._get()
+        stats = response.context.get('stats', {}) if response.context else {}
+        return response, stats
 
     def _make_repair(self, status, days_ago=0):
-        """Helper to create a Repair with given status and service_date."""
+        """Create a Repair with the given status and service_date offset."""
         svc_date = timezone.now() - timedelta(days=days_ago)
         return Repair.objects.create(
-            technician=self.technician,
+            technician=self.tech,
             customer=self.customer,
             tenant=self.tenant,
-            unit_number=f'UNIT-{status}-{days_ago}',
+            unit_number=f'U-{status}-{days_ago}-{Repair.objects.count()}',
             damage_type='Chip',
             queue_status=status,
             service_date=svc_date,
             cost=50,
         )
 
-    def _get_stats(self):
-        """Make a GET to repair_list and return the stats context dict."""
-        response = self.client.get(
-            '/tech/repairs/',
-            HTTP_HOST=f'{self.tenant.subdomain}.rssystems.io',
-        )
-        return response, response.context.get('stats', {})
-
     def test_repair_list_returns_200(self):
-        """repair_list() should return 200 OK for an admin user."""
-        response, _ = self._get_stats()
+        """repair_list() returns 200 OK for a manager user."""
+        response = self._get()
         self.assertEqual(response.status_code, 200)
 
     def test_stats_empty_with_no_repairs(self):
-        """All stat counters should be 0 when there are no repairs."""
+        """All stat counters are 0 when there are no repairs."""
         _, stats = self._get_stats()
-        self.assertEqual(stats['total_active'], 0)
-        self.assertEqual(stats['pending_approval'], 0)
-        self.assertEqual(stats['in_progress'], 0)
-        self.assertEqual(stats['completed_this_week'], 0)
+        self.assertEqual(stats.get('total_active'), 0)
+        self.assertEqual(stats.get('pending_approval'), 0)
+        self.assertEqual(stats.get('in_progress'), 0)
+        self.assertEqual(stats.get('completed_this_week'), 0)
 
     def test_total_active_excludes_completed(self):
         """total_active counts all non-COMPLETED repairs."""
@@ -114,7 +142,7 @@ class TechnicianRepairListStatsAggregationTest(TestCase):
         self._make_repair('REQUESTED')
         _, stats = self._get_stats()
         # APPROVED + IN_PROGRESS + REQUESTED = 3 active
-        self.assertEqual(stats['total_active'], 3)
+        self.assertEqual(stats.get('total_active'), 3)
 
     def test_pending_approval_counts_requested(self):
         """pending_approval counts only REQUESTED repairs."""
@@ -122,7 +150,7 @@ class TechnicianRepairListStatsAggregationTest(TestCase):
         self._make_repair('REQUESTED')
         self._make_repair('APPROVED')
         _, stats = self._get_stats()
-        self.assertEqual(stats['pending_approval'], 2)
+        self.assertEqual(stats.get('pending_approval'), 2)
 
     def test_in_progress_counts_in_progress(self):
         """in_progress counts only IN_PROGRESS repairs."""
@@ -130,40 +158,40 @@ class TechnicianRepairListStatsAggregationTest(TestCase):
         self._make_repair('IN_PROGRESS')
         self._make_repair('APPROVED')
         _, stats = self._get_stats()
-        self.assertEqual(stats['in_progress'], 2)
+        self.assertEqual(stats.get('in_progress'), 2)
 
-    def test_completed_this_week_counts_recent_completed(self):
+    def test_completed_this_week_counts_recent(self):
         """completed_this_week counts COMPLETED repairs from the last 7 days."""
-        self._make_repair('COMPLETED', days_ago=0)   # today — should count
-        self._make_repair('COMPLETED', days_ago=6)   # 6 days ago — should count
-        self._make_repair('COMPLETED', days_ago=8)   # 8 days ago — should NOT count
+        self._make_repair('COMPLETED', days_ago=0)   # today — counts
+        self._make_repair('COMPLETED', days_ago=6)   # 6 days ago — counts
+        self._make_repair('COMPLETED', days_ago=8)   # 8 days ago — does NOT count
         _, stats = self._get_stats()
-        self.assertEqual(stats['completed_this_week'], 2)
+        self.assertEqual(stats.get('completed_this_week'), 2)
 
     def test_completed_outside_week_not_counted(self):
-        """Repairs completed more than 7 days ago must not appear in completed_this_week."""
+        """Repairs completed >7 days ago must not appear in completed_this_week."""
         self._make_repair('COMPLETED', days_ago=10)
         self._make_repair('COMPLETED', days_ago=30)
         _, stats = self._get_stats()
-        self.assertEqual(stats['completed_this_week'], 0)
+        self.assertEqual(stats.get('completed_this_week'), 0)
 
     def test_all_stats_correct_together(self):
         """All four stats are correct when repairs in multiple statuses exist."""
-        self._make_repair('REQUESTED')          # active + pending
-        self._make_repair('IN_PROGRESS')        # active + in_progress
-        self._make_repair('APPROVED')           # active only
-        self._make_repair('COMPLETED', days_ago=2)   # completed this week
-        self._make_repair('COMPLETED', days_ago=20)  # completed, not this week
+        self._make_repair('REQUESTED')              # active + pending
+        self._make_repair('IN_PROGRESS')            # active + in_progress
+        self._make_repair('APPROVED')               # active only
+        self._make_repair('COMPLETED', days_ago=2)  # completed this week
+        self._make_repair('COMPLETED', days_ago=20) # completed, not this week
         _, stats = self._get_stats()
-        self.assertEqual(stats['total_active'], 3)
-        self.assertEqual(stats['pending_approval'], 1)
-        self.assertEqual(stats['in_progress'], 1)
-        self.assertEqual(stats['completed_this_week'], 1)
+        self.assertEqual(stats.get('total_active'), 3)
+        self.assertEqual(stats.get('pending_approval'), 1)
+        self.assertEqual(stats.get('in_progress'), 1)
+        self.assertEqual(stats.get('completed_this_week'), 1)
 
-    def test_total_repairs_matches_sum(self):
+    def test_total_repairs_in_context(self):
         """total_repairs in context matches the actual number of repairs."""
         self._make_repair('APPROVED')
         self._make_repair('COMPLETED')
         self._make_repair('REQUESTED')
-        response, _ = self._get_stats()
+        response = self._get()
         self.assertEqual(response.context.get('total_repairs'), 3)

--- a/tests/bug_fixes/test_code152_s3_cleanup_on_delete.py
+++ b/tests/bug_fixes/test_code152_s3_cleanup_on_delete.py
@@ -1,0 +1,117 @@
+"""
+CODE-152: Regression tests — S3 cleanup when invoices are deleted.
+
+Bug: Deleting invoices (via bulk delete or single delete) left orphaned PDF
+objects in S3.  Voided invoices correctly kept their PDFs for audit trail,
+but actually-deleted invoices should clean up after themselves.
+
+Fix: Added Invoice.delete() override that calls _delete_s3_object() before
+the DB row is removed.  Also changed the bulk delete path in
+owner_invoice_bulk_action to loop over instances (not QuerySet.delete())
+so the model override fires.
+
+Tests verify:
+1. Invoice.delete() calls _delete_s3_object when s3_key is set.
+2. Invoice.delete() is a no-op for S3 when s3_key is empty.
+3. S3 errors during deletion don't block invoice deletion.
+4. _delete_s3_object calls boto3 correctly with bucket + key.
+"""
+
+from unittest.mock import patch, MagicMock
+from decimal import Decimal
+
+from django.test import TestCase, override_settings
+from django.contrib.auth.models import User
+
+from apps.billing.models import Invoice, BillingConfig
+from apps.tenants.models import Tenant, TenantMembership
+
+
+class InvoiceS3CleanupOnDeleteTest(TestCase):
+    """Tests for S3 object cleanup when invoices are hard-deleted."""
+
+    def setUp(self):
+        self.user = User.objects.create_user('owner152', password='test')
+        self.tenant = Tenant.objects.create(
+            name='S3 Cleanup Shop', slug='s3-cleanup-shop', owner=self.user,
+        )
+        TenantMembership.objects.create(user=self.user, tenant=self.tenant, role='owner')
+
+        from core.models import Customer
+        self.customer = Customer.objects.create(
+            name='Cleanup Customer', tenant=self.tenant,
+        )
+
+    def _make_invoice(self, s3_key='', status='DRAFT'):
+        return Invoice.objects.create(
+            tenant=self.tenant,
+            customer=self.customer,
+            invoice_number=f'INV-CLEANUP-{Invoice.objects.count() + 1}',
+            subtotal=Decimal('100.00'),
+            total=Decimal('100.00'),
+            status=status,
+            s3_key=s3_key,
+        )
+
+    @patch.object(Invoice, '_delete_s3_object')
+    def test_delete_calls_s3_cleanup(self, mock_s3_delete):
+        """Invoice.delete() should call _delete_s3_object."""
+        invoice = self._make_invoice(s3_key='invoices/42/test.pdf')
+        invoice_id = invoice.id
+        invoice.delete()
+        mock_s3_delete.assert_called_once()
+        self.assertFalse(Invoice.all_objects.filter(id=invoice_id).exists())
+
+    @patch.object(Invoice, '_delete_s3_object')
+    def test_delete_calls_s3_cleanup_even_without_key(self, mock_s3_delete):
+        """Invoice.delete() always calls _delete_s3_object (method handles empty key)."""
+        invoice = self._make_invoice(s3_key='')
+        invoice.delete()
+        mock_s3_delete.assert_called_once()
+
+    def test_delete_s3_object_skips_when_no_key(self):
+        """_delete_s3_object is a no-op when s3_key is empty."""
+        invoice = self._make_invoice(s3_key='')
+        # Should not raise and should not attempt any S3 call
+        invoice._delete_s3_object()  # no-op, just returns
+
+    @override_settings(AWS_STORAGE_BUCKET_NAME=None)
+    def test_delete_s3_object_skips_when_no_bucket(self):
+        """_delete_s3_object skips when AWS_STORAGE_BUCKET_NAME is unset."""
+        invoice = self._make_invoice(s3_key='invoices/1/test.pdf')
+        # Should not raise
+        invoice._delete_s3_object()
+
+    @override_settings(AWS_STORAGE_BUCKET_NAME='test-bucket')
+    @patch('boto3.client')
+    def test_delete_s3_object_calls_boto3(self, mock_boto3_client):
+        """_delete_s3_object calls S3 delete_object with correct params."""
+        mock_client = MagicMock()
+        mock_boto3_client.return_value = mock_client
+
+        invoice = self._make_invoice(s3_key='invoices/42/invoice_INV-1.pdf')
+        invoice._delete_s3_object()
+
+        mock_boto3_client.assert_called_once_with('s3')
+        mock_client.delete_object.assert_called_once_with(
+            Bucket='test-bucket',
+            Key='invoices/42/invoice_INV-1.pdf',
+        )
+
+    @override_settings(AWS_STORAGE_BUCKET_NAME='test-bucket')
+    @patch('boto3.client')
+    def test_delete_s3_object_swallows_errors(self, mock_boto3_client):
+        """S3 errors shouldn't propagate — deletion must still succeed."""
+        mock_client = MagicMock()
+        mock_client.delete_object.side_effect = Exception('S3 unavailable')
+        mock_boto3_client.return_value = mock_client
+
+        invoice = self._make_invoice(s3_key='invoices/99/some.pdf')
+        invoice_id = invoice.id
+
+        # _delete_s3_object should not raise
+        invoice._delete_s3_object()
+
+        # Full delete should also work
+        invoice.delete()
+        self.assertFalse(Invoice.all_objects.filter(id=invoice_id).exists())

--- a/tests/bug_fixes/test_code153_decimal_zero_pricing.py
+++ b/tests/bug_fixes/test_code153_decimal_zero_pricing.py
@@ -1,0 +1,182 @@
+"""
+CODE-153: Regression tests for Decimal('0.00') falsy bug in pricing service.
+
+Two locations used bare truthiness checks on Decimal fields:
+
+1. CustomerPricing.get_repair_price() — "if self.repair_1_price:" treated
+   Decimal('0.00') as "not configured", returning None and falling back to the
+   standard $50 rate instead of honouring the intentional $0 custom price.
+
+2. get_tenant_repair_price() — "tenant.repair_price_1 or DEFAULT_PRICING[1]"
+   silently replaced a $0 tenant tier with the $50 system default.
+
+This is the same Decimal-falsy anti-pattern fixed in CODE-132 (approval_limit)
+and CODE-151 (InvoiceLineItem.save).  Both are documented in AGENTS.md.
+
+Impact:
+  - Customers configured for free service (warranty, goodwill, etc.) were
+    silently charged the standard rate when a technician created a repair.
+  - Tenants that set a $0 pricing tier (e.g. for promotional periods) always
+    received the default price instead.
+"""
+
+from decimal import Decimal
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from apps.customer_portal.pricing_models import CustomerPricing
+from apps.technician_portal.services.pricing_service import (
+    get_tenant_repair_price,
+    calculate_repair_cost,
+)
+from core.models import Customer
+from apps.tenants.models import Tenant
+
+
+def _make_tenant(name, slug):
+    """Create a Tenant with a required owner user."""
+    owner = User.objects.create_user(
+        username=f'owner_{slug}',
+        email=f'owner_{slug}@example.com',
+        password='testpass',
+    )
+    return Tenant.objects.create(name=name, slug=slug, owner=owner)
+
+
+class CustomerPricingZeroTest(TestCase):
+    """CustomerPricing.get_repair_price() must treat Decimal('0.00') as a valid price."""
+
+    def setUp(self):
+        self.tenant = _make_tenant('Test Shop', 'test-shop')
+        self.customer = Customer.objects.create(
+            name='Free Service Fleet',
+            tenant=self.tenant,
+        )
+        self.pricing = CustomerPricing.objects.create(
+            customer=self.customer,
+            use_custom_pricing=True,
+            repair_1_price=Decimal('0.00'),
+            repair_2_price=Decimal('0.00'),
+            repair_3_price=Decimal('0.00'),
+            repair_4_price=Decimal('0.00'),
+            repair_5_plus_price=Decimal('0.00'),
+        )
+
+    def test_zero_price_tier1_not_treated_as_unset(self):
+        """$0 custom price for tier 1 must return 0.00, not None."""
+        result = self.pricing.get_repair_price(1)
+        self.assertIsNotNone(result, "Decimal('0.00') must not be treated as None")
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_zero_price_tier2_not_treated_as_unset(self):
+        result = self.pricing.get_repair_price(2)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_zero_price_tier3_not_treated_as_unset(self):
+        result = self.pricing.get_repair_price(3)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_zero_price_tier4_not_treated_as_unset(self):
+        result = self.pricing.get_repair_price(4)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_zero_price_tier5plus_not_treated_as_unset(self):
+        result = self.pricing.get_repair_price(5)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_zero_price_tier5plus_for_count_10(self):
+        result = self.pricing.get_repair_price(10)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_null_price_tier_returns_none(self):
+        """Null (unset) tier should still return None (fall back to default)."""
+        pricing_partial = CustomerPricing.objects.create(
+            customer=Customer.objects.create(name='Partial Fleet', tenant=self.tenant, email='partial@example.com'),
+            use_custom_pricing=True,
+            repair_1_price=Decimal('45.00'),
+            repair_2_price=None,   # not configured
+        )
+        self.assertEqual(pricing_partial.get_repair_price(1), Decimal('45.00'))
+        self.assertIsNone(pricing_partial.get_repair_price(2))
+
+    def test_calculate_repair_cost_uses_zero_custom_price(self):
+        """calculate_repair_cost() must propagate $0 custom price through to caller."""
+        cost = calculate_repair_cost(self.customer, 1, self.tenant)
+        self.assertEqual(cost, Decimal('0.00'),
+                         "repair cost should be $0.00 for free-service account, not default $50")
+
+    def test_non_zero_custom_price_unaffected(self):
+        """Normal positive custom prices still work correctly."""
+        pricing_normal = CustomerPricing.objects.create(
+            customer=Customer.objects.create(name='Normal Fleet', tenant=self.tenant, email='normal@example.com'),
+            use_custom_pricing=True,
+            repair_1_price=Decimal('42.00'),
+        )
+        result = pricing_normal.get_repair_price(1)
+        self.assertEqual(result, Decimal('42.00'))
+
+    def test_custom_pricing_disabled_returns_none(self):
+        """When use_custom_pricing=False, get_repair_price should return None regardless."""
+        pricing_off = CustomerPricing.objects.create(
+            customer=Customer.objects.create(name='Default Fleet', tenant=self.tenant, email='default@example.com'),
+            use_custom_pricing=False,
+            repair_1_price=Decimal('0.00'),
+        )
+        self.assertIsNone(pricing_off.get_repair_price(1))
+
+
+class TenantPricingZeroTest(TestCase):
+    """get_tenant_repair_price() must treat Decimal('0.00') as a valid configured price."""
+
+    def setUp(self):
+        self.tenant = _make_tenant('Zero Price Shop', 'zero-shop')
+        # Set all pricing tiers to $0
+        self.tenant.repair_price_1 = Decimal('0.00')
+        self.tenant.repair_price_2 = Decimal('0.00')
+        self.tenant.repair_price_3 = Decimal('0.00')
+        self.tenant.repair_price_4 = Decimal('0.00')
+        self.tenant.repair_price_5_plus = Decimal('0.00')
+        self.tenant.save()
+
+    def test_zero_tenant_price_tier1(self):
+        result = get_tenant_repair_price(self.tenant, 1)
+        self.assertEqual(result, Decimal('0.00'),
+                         "Tenant $0 tier-1 price must not fall back to $50 default")
+
+    def test_zero_tenant_price_tier2(self):
+        result = get_tenant_repair_price(self.tenant, 2)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_zero_tenant_price_tier3(self):
+        result = get_tenant_repair_price(self.tenant, 3)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_zero_tenant_price_tier4(self):
+        result = get_tenant_repair_price(self.tenant, 4)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_zero_tenant_price_tier5plus(self):
+        result = get_tenant_repair_price(self.tenant, 5)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_zero_tenant_price_tier5plus_high_count(self):
+        result = get_tenant_repair_price(self.tenant, 20)
+        self.assertEqual(result, Decimal('0.00'))
+
+    def test_none_tenant_uses_default(self):
+        """When no tenant, default pricing should apply."""
+        result = get_tenant_repair_price(None, 1)
+        self.assertEqual(result, Decimal('50.00'))
+
+    def test_normal_tenant_prices_unaffected(self):
+        """Normal positive tenant prices work as before."""
+        normal_tenant = _make_tenant('Normal Shop', 'normal-shop')
+        normal_tenant.repair_price_1 = Decimal('55.00')
+        normal_tenant.save()
+        result = get_tenant_repair_price(normal_tenant, 1)
+        self.assertEqual(result, Decimal('55.00'))

--- a/tests/bug_fixes/test_code153_payment_terms_override.py
+++ b/tests/bug_fixes/test_code153_payment_terms_override.py
@@ -1,0 +1,191 @@
+"""
+CODE-153: Regression tests — payment terms override on invoice generation.
+
+Feature: When generating an invoice (via API or repair detail page), the
+owner/manager can override the default payment terms for that specific
+invoice.  The form shows the shop's default but allows changing it.
+
+Tests verify:
+1. API accepts payment_terms and applies it to the created invoice.
+2. API without payment_terms falls back to BillingConfig default.
+3. Invalid payment_terms returns 400.
+4. payment_terms correctly derives due_days (NET30 → 30 days).
+5. owner_generate_invoice_from_repair accepts POST payment_terms.
+"""
+
+import json
+from datetime import timedelta
+from decimal import Decimal
+
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from apps.billing.models import Invoice, BillingConfig
+from apps.tenants.models import Tenant, TenantMembership
+from apps.technician_portal.models import Technician, Repair
+from core.models import Customer
+
+
+class PaymentTermsOverrideAPITest(TestCase):
+    """Tests for payment_terms override via the billing API."""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner_user = User.objects.create_user('owner153', password='test')
+        self.tenant = Tenant.objects.create(
+            name='Terms Shop', slug='terms-shop', owner=self.owner_user,
+        )
+        TenantMembership.objects.create(
+            user=self.owner_user, tenant=self.tenant, role='owner',
+        )
+        self.customer = Customer.objects.create(
+            name='Terms Customer', tenant=self.tenant,
+        )
+        self.tech = Technician.objects.create(
+            user=self.owner_user, tenant=self.tenant,
+        )
+        # BillingConfig with COD default
+        self.billing_config = BillingConfig.objects.create(
+            tenant=self.tenant,
+            default_payment_terms='COD',
+        )
+        # Completed repair ready to invoice
+        self.repair = Repair.objects.create(
+            customer=self.customer,
+            tenant=self.tenant,
+            technician=self.tech,
+            unit_number='TERMS-1',
+            queue_status='COMPLETED',
+            cost=Decimal('75.00'),
+            service_date=timezone.now(),
+        )
+        self.client.login(username='owner153', password='test')
+
+    def test_api_creates_invoice_with_override_terms(self):
+        """POST with payment_terms='NET30' should set NET30 on the invoice."""
+        resp = self.client.post(
+            f'/api/billing/invoices/create/{self.customer.id}/',
+            data=json.dumps({
+                'repair_ids': [self.repair.id],
+                'payment_terms': 'NET30',
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data.get('success'), data)
+
+        invoice = Invoice.objects.get(customer=self.customer, tenant=self.tenant)
+        self.assertEqual(invoice.payment_terms, 'NET30')
+        # Due date should be ~30 days from today
+        expected_due = timezone.now().date() + timedelta(days=30)
+        self.assertEqual(invoice.due_date, expected_due)
+
+    def test_api_falls_back_to_config_default(self):
+        """POST without payment_terms should use BillingConfig default (COD)."""
+        resp = self.client.post(
+            f'/api/billing/invoices/create/{self.customer.id}/',
+            data=json.dumps({
+                'repair_ids': [self.repair.id],
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 200)
+        invoice = Invoice.objects.get(customer=self.customer, tenant=self.tenant)
+        self.assertEqual(invoice.payment_terms, 'COD')
+
+    def test_api_rejects_invalid_terms(self):
+        """POST with invalid payment_terms should return 400."""
+        resp = self.client.post(
+            f'/api/billing/invoices/create/{self.customer.id}/',
+            data=json.dumps({
+                'repair_ids': [self.repair.id],
+                'payment_terms': 'NET999',
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('Invalid payment_terms', resp.json().get('error', ''))
+
+    def test_api_net60_gives_60_day_due_date(self):
+        """NET60 should produce a due date 60 days from today."""
+        resp = self.client.post(
+            f'/api/billing/invoices/create/{self.customer.id}/',
+            data=json.dumps({
+                'repair_ids': [self.repair.id],
+                'payment_terms': 'NET60',
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 200)
+        invoice = Invoice.objects.get(customer=self.customer, tenant=self.tenant)
+        self.assertEqual(invoice.payment_terms, 'NET60')
+        expected_due = timezone.now().date() + timedelta(days=60)
+        self.assertEqual(invoice.due_date, expected_due)
+
+
+class PaymentTermsOverrideRepairDetailTest(TestCase):
+    """Tests for payment_terms override via the repair detail generate button."""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner_user = User.objects.create_user('owner153b', password='test')
+        self.tenant = Tenant.objects.create(
+            name='Detail Shop', slug='detail-shop', owner=self.owner_user,
+        )
+        TenantMembership.objects.create(
+            user=self.owner_user, tenant=self.tenant, role='owner',
+        )
+        self.customer = Customer.objects.create(
+            name='Detail Customer', tenant=self.tenant,
+        )
+        self.tech = Technician.objects.create(
+            user=self.owner_user, tenant=self.tenant,
+        )
+        BillingConfig.objects.create(
+            tenant=self.tenant,
+            default_payment_terms='COD',
+        )
+        self.repair = Repair.objects.create(
+            customer=self.customer,
+            tenant=self.tenant,
+            technician=self.tech,
+            unit_number='DETAIL-1',
+            queue_status='COMPLETED',
+            cost=Decimal('50.00'),
+            service_date=timezone.now(),
+        )
+        self.client.login(username='owner153b', password='test')
+
+    def test_generate_from_repair_with_terms_override(self):
+        """POST with payment_terms='NET15' should create invoice with NET15."""
+        resp = self.client.post(
+            f'/owner/invoices/generate-from-repair/{self.repair.id}/',
+            data={'payment_terms': 'NET15'},
+        )
+        # Should redirect to invoice detail
+        self.assertEqual(resp.status_code, 302)
+        invoice = Invoice.objects.get(customer=self.customer, tenant=self.tenant)
+        self.assertEqual(invoice.payment_terms, 'NET15')
+        expected_due = timezone.now().date() + timedelta(days=15)
+        self.assertEqual(invoice.due_date, expected_due)
+
+    def test_generate_from_repair_without_terms_uses_default(self):
+        """POST without payment_terms should use BillingConfig default."""
+        resp = self.client.post(
+            f'/owner/invoices/generate-from-repair/{self.repair.id}/',
+        )
+        self.assertEqual(resp.status_code, 302)
+        invoice = Invoice.objects.get(customer=self.customer, tenant=self.tenant)
+        self.assertEqual(invoice.payment_terms, 'COD')
+
+    def test_generate_from_repair_ignores_invalid_terms(self):
+        """POST with invalid payment_terms should fall back to default (not error)."""
+        resp = self.client.post(
+            f'/owner/invoices/generate-from-repair/{self.repair.id}/',
+            data={'payment_terms': 'BOGUS'},
+        )
+        self.assertEqual(resp.status_code, 302)
+        invoice = Invoice.objects.get(customer=self.customer, tenant=self.tenant)
+        self.assertEqual(invoice.payment_terms, 'COD')  # fallback to default

--- a/tests/bug_fixes/test_code154_account_settings_prefs_desync.py
+++ b/tests/bug_fixes/test_code154_account_settings_prefs_desync.py
@@ -1,0 +1,265 @@
+"""
+CODE-154: Regression test — account_settings prefs/customer verification desync.
+
+Bug: In `apps/customer_portal/views.py` → `account_settings()`, the view
+previously called `prefs.save()` eagerly inside the email-change and phone-change
+blocks, BEFORE the password validation check. When a user changed their phone
+number AND also attempted (and failed) a password change in the same form
+submission, the following happened:
+
+1. Phone change detected → `customer.phone_verified = False` (in memory only)
+   → `prefs.phone_verified = False` → `prefs.save()` ← COMMITTED TO DB
+2. Password check fails → early `return render(...)` 
+3. `customer.save()` is never reached → `customer.phone_verified` stays True in DB
+
+Result: `CustomerNotificationPreference.phone_verified = False` while
+`Customer.phone_verified = True` — a permanent desync. The customer's
+notification preference says unverified but the Customer record says verified.
+
+Identical issue exists for email changes combined with a bad password attempt.
+
+Fix: Validate the password BEFORE any save calls. Collect prefs changes in a
+staging dict (`prefs_updates`) and apply them together with `customer.save()` at
+the very end of the happy path.
+
+Tests verify:
+1. Successful phone+password change updates both Customer and prefs atomically.
+2. Phone change + bad password: neither Customer nor prefs phone_verified changes.
+3. Phone change + good password: both Customer.phone and prefs.phone_verified
+   are updated consistently.
+4. Email change + bad password: neither Customer nor prefs email_verified changes.
+5. Email change + good password: both updated consistently.
+6. Phone change only (no password): Customer.phone and prefs updated correctly.
+"""
+
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from core.models import Customer
+from apps.customer_portal.models import CustomerUser
+from core.models.notification_preferences import CustomerNotificationPreference
+from apps.tenants.models import Tenant, TenantMembership
+
+
+def _make_tenant(name='Test Shop'):
+    return Tenant.objects.create(name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_user(email, password='testpass123', first='Test', last='User'):
+    user = User.objects.create_user(
+        username=email,
+        email=email,
+        password=password,
+        first_name=first,
+        last_name=last,
+    )
+    return user
+
+
+def _make_customer(tenant, name='Acme Corp', email='acme@example.com', phone='555-0100'):
+    return Customer.objects.create(
+        tenant=tenant,
+        name=name,
+        email=email,
+        phone=phone,
+        phone_verified=True,
+        email_verified=True,
+    )
+
+
+def _make_customer_user(user, customer):
+    return CustomerUser.objects.create(user=user, customer=customer)
+
+
+class AccountSettingsPrefsDesyncTest(TestCase):
+    """Regression tests for CODE-154: prefs/customer verification desync."""
+
+    def setUp(self):
+        self.tenant = _make_tenant('Sync Test Shop')
+        self.user = _make_user('synctest@example.com', password='OldPass123!')
+        self.customer = _make_customer(self.tenant, phone='555-0100')
+        self.customer_user = _make_customer_user(self.user, self.customer)
+
+        # Create notification prefs with verified state
+        self.prefs = CustomerNotificationPreference.objects.create(
+            customer=self.customer,
+            phone_verified=True,
+            email_verified=True,
+        )
+
+        self.client = Client()
+        self.client.login(username='synctest@example.com', password='OldPass123!')
+
+        # Set tenant in session (customer portal expects tenant_id)
+        session = self.client.session
+        session['tenant_id'] = self.tenant.id
+        session.save()
+
+    def _post_settings(self, data):
+        return self.client.post(reverse('customer_account_settings'), data, follow=False)
+
+    # ------------------------------------------------------------------
+    # Test 1: Phone change + wrong password → NO changes persisted
+    # ------------------------------------------------------------------
+    def test_phone_change_bad_password_no_desync(self):
+        """
+        If the user changes phone + provides wrong current_password, NEITHER
+        Customer.phone_verified NOR CustomerNotificationPreference.phone_verified
+        should change. Previously prefs was saved eagerly before the password check.
+        """
+        response = self._post_settings({
+            'first_name': 'Test',
+            'last_name': 'User',
+            'email': 'synctest@example.com',
+            'phone': '555-9999',  # changed
+            'current_password': 'WRONG_PASSWORD',
+            'new_password': 'NewPass456!',
+            'confirm_password': 'NewPass456!',
+        })
+
+        # Should not redirect (password failed)
+        self.assertNotEqual(response.status_code, 302)
+
+        # Reload from DB — nothing should have changed
+        self.customer.refresh_from_db()
+        self.prefs.refresh_from_db()
+
+        self.assertEqual(self.customer.phone, '555-0100', "Customer.phone should be unchanged")
+        self.assertTrue(self.customer.phone_verified, "Customer.phone_verified should stay True")
+        self.assertTrue(self.prefs.phone_verified, "prefs.phone_verified should stay True — was incorrectly saved False before fix")
+
+    # ------------------------------------------------------------------
+    # Test 2: Email change + wrong password → NO changes persisted
+    # ------------------------------------------------------------------
+    def test_email_change_bad_password_no_desync(self):
+        """
+        If the user changes email + provides wrong current_password, NEITHER
+        Customer.email_verified NOR prefs.email_verified should change.
+        """
+        response = self._post_settings({
+            'first_name': 'Test',
+            'last_name': 'User',
+            'email': 'newemail@example.com',  # changed
+            'phone': '555-0100',
+            'current_password': 'WRONG_PASSWORD',
+            'new_password': 'NewPass456!',
+            'confirm_password': 'NewPass456!',
+        })
+
+        self.assertNotEqual(response.status_code, 302)
+
+        self.user.refresh_from_db()
+        self.customer.refresh_from_db()
+        self.prefs.refresh_from_db()
+
+        self.assertEqual(self.user.email, 'synctest@example.com', "User.email should be unchanged")
+        self.assertTrue(self.customer.email_verified, "Customer.email_verified should stay True")
+        self.assertTrue(self.prefs.email_verified, "prefs.email_verified should stay True")
+
+    # ------------------------------------------------------------------
+    # Test 3: Phone change with NO password change → updates both atomically
+    # ------------------------------------------------------------------
+    def test_phone_change_no_password_updates_both(self):
+        """
+        If the user just changes their phone (no password), both
+        Customer.phone and prefs.phone_verified should update consistently.
+        """
+        response = self._post_settings({
+            'first_name': 'Test',
+            'last_name': 'User',
+            'email': 'synctest@example.com',
+            'phone': '555-7777',  # changed
+        })
+
+        # Should redirect to dashboard on success
+        self.assertEqual(response.status_code, 302)
+
+        self.customer.refresh_from_db()
+        self.prefs.refresh_from_db()
+
+        self.assertEqual(self.customer.phone, '555-7777', "Customer.phone should update")
+        self.assertFalse(self.customer.phone_verified, "Customer.phone_verified should be reset to False")
+        self.assertFalse(self.prefs.phone_verified, "prefs.phone_verified should also be reset to False")
+
+    # ------------------------------------------------------------------
+    # Test 4: Phone change + correct password → both updated atomically
+    # ------------------------------------------------------------------
+    def test_phone_change_good_password_updates_both(self):
+        """
+        Phone change + valid password change: both Customer.phone/phone_verified
+        and prefs.phone_verified update correctly, and password is changed.
+        """
+        response = self._post_settings({
+            'first_name': 'Test',
+            'last_name': 'User',
+            'email': 'synctest@example.com',
+            'phone': '555-8888',  # changed
+            'current_password': 'OldPass123!',
+            'new_password': 'NewPass456!',
+            'confirm_password': 'NewPass456!',
+        })
+
+        self.assertEqual(response.status_code, 302)
+
+        self.user.refresh_from_db()
+        self.customer.refresh_from_db()
+        self.prefs.refresh_from_db()
+
+        self.assertEqual(self.customer.phone, '555-8888', "Customer.phone should update")
+        self.assertFalse(self.customer.phone_verified, "Customer.phone_verified should be False")
+        self.assertFalse(self.prefs.phone_verified, "prefs.phone_verified should be False (in sync)")
+        self.assertTrue(self.user.check_password('NewPass456!'), "Password should be changed")
+
+    # ------------------------------------------------------------------
+    # Test 5: Password-mismatch early return doesn't save prefs
+    # ------------------------------------------------------------------
+    def test_phone_change_password_mismatch_no_save(self):
+        """
+        Phone change + mismatched new/confirm passwords → early return,
+        neither Customer nor prefs should change.
+        """
+        response = self._post_settings({
+            'first_name': 'Test',
+            'last_name': 'User',
+            'email': 'synctest@example.com',
+            'phone': '555-4444',  # changed
+            'current_password': 'OldPass123!',
+            'new_password': 'NewPass456!',
+            'confirm_password': 'DOESNOTMATCH',
+        })
+
+        self.assertNotEqual(response.status_code, 302)
+
+        self.customer.refresh_from_db()
+        self.prefs.refresh_from_db()
+
+        self.assertEqual(self.customer.phone, '555-0100', "Customer.phone should be unchanged")
+        self.assertTrue(self.customer.phone_verified, "Customer.phone_verified should stay True")
+        self.assertTrue(self.prefs.phone_verified, "prefs.phone_verified should stay True")
+
+    # ------------------------------------------------------------------
+    # Test 6: Short new password early return doesn't save prefs
+    # ------------------------------------------------------------------
+    def test_phone_change_short_password_no_save(self):
+        """
+        Phone change + new password too short → early return, no state change.
+        """
+        response = self._post_settings({
+            'first_name': 'Test',
+            'last_name': 'User',
+            'email': 'synctest@example.com',
+            'phone': '555-3333',  # changed
+            'current_password': 'OldPass123!',
+            'new_password': 'short',
+            'confirm_password': 'short',
+        })
+
+        self.assertNotEqual(response.status_code, 302)
+
+        self.customer.refresh_from_db()
+        self.prefs.refresh_from_db()
+
+        self.assertEqual(self.customer.phone, '555-0100')
+        self.assertTrue(self.customer.phone_verified)
+        self.assertTrue(self.prefs.phone_verified)


### PR DESCRIPTION
## Summary
4 commits stacked on autonomous-work since PR #65 merged.

### Mobile UI Fixes (CODE-155)
- **Owner invoices batch bar:** Buttons collapse to icon-only on mobile, text labels appear at sm+ breakpoint
- **Uninvoiced work rows:** Customer name truncates properly, total shown inline on mobile, Create/Dismiss buttons go icon-only
- **Invoice detail actions:** All action buttons (Send, PDF, Email, Void, Remind) collapse to icons on narrow screens, flex-wrap prevents clipping
- **Account settings (CODE-154):** Fixed notification prefs desync when updating email/phone (repair prefs were overwritten by profile save)

### S3 Cleanup on Invoice Delete (CODE-152)
- Invoice PDFs are deleted from S3 when invoice is deleted
- Voided invoices keep their PDF for audit trail
- 6 regression tests

### Payment Terms Override (CODE-153)
- Invoice creation modal includes a Payment Terms dropdown (defaults to shop's configured terms)
- Can be changed per-invoice at creation time
- Same dropdown on repair detail "Generate Invoice" button
- API validates the value; due dates auto-derive from terms (NET30 → 30 days, etc)
- 7 regression tests

### N+1 Query Fix (CODE-151)
- Technician repair_list stats queries optimized — removed redundant per-page count queries

### Decimal Falsy Bug (CODE-153)
- `Decimal('0.00')` is falsy in Python — zero custom prices silently fell back to defaults
- Fixed with explicit `is not None` checks in pricing logic

## Test Coverage
~80 new/updated regression tests across all changes.