### PR TITLE
Public payment links — no-login pay from invoice emails

### DIFF
--- a/apps/billing/services/invoice_email_service.py
+++ b/apps/billing/services/invoice_email_service.py
@@ -354,29 +354,17 @@ class InvoiceEmailService:
                         invoice_record = inv_qs.order_by('-created_at').first()
 
                     if invoice_record:
-                        # Use existing Stripe URL if available
-                        if invoice_record.stripe_hosted_url:
-                            payment_link = invoice_record.stripe_hosted_url
-                        else:
-                            # Generate a fresh Stripe Checkout session
-                            try:
-                                from apps.tenants.services.connect_service import ConnectService
-                                connect_svc = ConnectService()
-                                base_url = getattr(settings, 'BASE_URL', 'https://rssystems.io')
-                                result = connect_svc.create_connected_checkout_session(
-                                    invoice_record,
-                                    success_url=f"{base_url}/app/invoices/{invoice_record.id}/?payment=success",
-                                    cancel_url=f"{base_url}/app/invoices/{invoice_record.id}/?payment=cancelled",
-                                )
-                                if result.get('checkout_url'):
-                                    payment_link = result['checkout_url']
-                                    # Save for reuse
-                                    invoice_record.stripe_hosted_url = payment_link
-                                    invoice_record.save(update_fields=['stripe_hosted_url'])
-                            except Exception as e:
-                                logger.warning(f"Could not create Stripe checkout for email: {e}")
-                                # Fall back to portal link
-                                payment_link = f"https://rssystems.io/app/invoices/{invoice_record.id}/"
+                        # Generate public payment URL (HMAC-token based, no login needed)
+                        # This URL will redirect to Stripe Checkout if available,
+                        # or show a fallback page with contact info.
+                        try:
+                            from rs_systems.views import generate_payment_token
+                            base_url = getattr(settings, 'BASE_URL', 'https://rssystems.io')
+                            token = generate_payment_token(invoice_record.id)
+                            payment_link = f"{base_url}/pay/{invoice_record.id}/{token}/"
+                        except Exception as e:
+                            logger.warning(f"Could not generate payment URL: {e}")
+                            payment_link = f"https://rssystems.io/app/invoices/{invoice_record.id}/"
                 except Exception:
                     pass
             
@@ -442,7 +430,19 @@ class InvoiceEmailService:
     def _build_html_email(self, invoice_data, payment_link=None, include_photos=False) -> str:
         """Build an HTML email with clickable buttons."""
         invoice_id = getattr(invoice_data, 'id', None) or getattr(invoice_data, 'pk', None)
-        portal_url = f"https://rssystems.io/app/invoices/{invoice_id}/" if invoice_id else "https://rssystems.io/app/invoices/"
+        # Use the same public pay URL for "View Invoice" (no login required)
+        if payment_link:
+            portal_url = payment_link
+        elif invoice_id:
+            try:
+                from rs_systems.views import generate_payment_token
+                base_url = getattr(settings, 'BASE_URL', 'https://rssystems.io')
+                token = generate_payment_token(invoice_id)
+                portal_url = f"{base_url}/pay/{invoice_id}/{token}/"
+            except Exception:
+                portal_url = f"https://rssystems.io/app/invoices/{invoice_id}/"
+        else:
+            portal_url = "https://rssystems.io/app/invoices/"
 
         # Company info
         company_name = 'RS Systems'

--- a/apps/billing/tasks.py
+++ b/apps/billing/tasks.py
@@ -150,6 +150,20 @@ def _send_overdue_reminder(invoice, config, days_overdue):
         )
         subject = f"Reminder: Invoice #{invoice.invoice_number} is overdue"
     
+    # Generate public payment link
+    pay_link_text = ''
+    try:
+        from rs_systems.views import generate_payment_token
+        base_url = getattr(settings, 'BASE_URL', 'https://rssystems.io')
+        token = generate_payment_token(invoice.id)
+        pay_url = f"{base_url}/pay/{invoice.id}/{token}/"
+        pay_link_text = f"\nPay online: {pay_url}\n"
+    except Exception:
+        pass
+
+    _company_name = config.company_name or (invoice.tenant.name if invoice.tenant else '')
+    _company_phone = config.company_phone or (invoice.tenant.business_phone if invoice.tenant else '')
+
     # Build email body
     body = f"""Dear {customer.name},
 
@@ -160,14 +174,14 @@ Invoice Details:
   Invoice Date: {invoice.invoice_date.strftime('%B %d, %Y')}
   Due Date: {invoice.due_date.strftime('%B %d, %Y')}
   Amount Due: ${invoice.amount_due:.2f}
-
+{pay_link_text}
 Please submit payment at your earliest convenience.
 
 If you have already sent payment, please disregard this notice.
 
 Thank you,
-{config.company_name or (invoice.tenant.name if invoice.tenant else '')}
-{config.company_phone or (invoice.tenant.business_phone if invoice.tenant else '')}
+{_company_name}
+{_company_phone}
 """
     
     try:

--- a/rs_systems/urls.py
+++ b/rs_systems/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path('health/', views.health_check, name='health_check'),  # AWS health check endpoint
     path('payment-complete', views.payment_complete, name='payment_complete'),
     path('payment-cancelled', views.payment_cancelled, name='payment_cancelled'),
+    path('pay/<int:invoice_id>/<str:token>/', views.public_pay_invoice, name='public_pay_invoice'),
     # setup-database/ removed — security risk (unauthenticated DB setup with hardcoded creds)
 
     # Test/diagnostic endpoints (for debugging)

--- a/rs_systems/views.py
+++ b/rs_systems/views.py
@@ -416,6 +416,88 @@ def setup_database(request):
     """)
 
 
+def generate_payment_token(invoice_id):
+    """Generate an HMAC token for public invoice payment links."""
+    import hmac, hashlib
+    secret = settings.SECRET_KEY
+    message = f"pay-invoice-{invoice_id}"
+    return hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()[:32]
+
+
+def public_pay_invoice(request, invoice_id, token):
+    """
+    Public payment page — no login required.
+    Token is HMAC-derived from invoice ID + SECRET_KEY, so URLs are unforgeable.
+    """
+    import hmac as hmac_mod
+    expected = generate_payment_token(invoice_id)
+    if not hmac_mod.compare_digest(token, expected):
+        return render(request, '404.html', status=404)
+
+    from apps.billing.models import Invoice
+    try:
+        invoice = Invoice.objects.select_related('customer', 'tenant').get(id=invoice_id)
+    except Invoice.DoesNotExist:
+        return render(request, '404.html', status=404)
+
+    if invoice.status == 'PAID':
+        return render(request, 'billing/payment_complete.html')
+
+    if invoice.amount_due <= 0:
+        return render(request, 'billing/payment_complete.html')
+
+    # Try to create a Stripe Checkout session
+    checkout_url = None
+    error_msg = None
+    tenant = invoice.tenant
+
+    if tenant and tenant.can_accept_payments:
+        try:
+            from apps.tenants.services.connect_service import ConnectService
+            connect_svc = ConnectService()
+            base_url = getattr(settings, 'BASE_URL', 'https://rssystems.io')
+            result = connect_svc.create_connected_checkout_session(
+                invoice,
+                success_url=f"{base_url}/payment-complete?session={{CHECKOUT_SESSION_ID}}",
+                cancel_url=f"{base_url}/pay/{invoice_id}/{token}/",
+            )
+            if result.get('checkout_url'):
+                checkout_url = result['checkout_url']
+        except Exception as e:
+            logger.warning(f"Could not create checkout for public pay page: {e}")
+            error_msg = "Online payments are temporarily unavailable. Please contact the shop directly."
+    else:
+        # Try platform Stripe (non-Connect)
+        try:
+            from apps.billing.services.stripe_service import StripeService
+            svc = StripeService()
+            if svc.is_enabled():
+                base_url = getattr(settings, 'BASE_URL', 'https://rssystems.io')
+                result = svc.create_checkout_session(
+                    invoice,
+                    success_url=f"{base_url}/payment-complete?session={{CHECKOUT_SESSION_ID}}",
+                    cancel_url=f"{base_url}/pay/{invoice_id}/{token}/",
+                )
+                if result.get('checkout_url'):
+                    checkout_url = result['checkout_url']
+        except Exception as e:
+            logger.warning(f"Could not create platform checkout: {e}")
+            error_msg = "Online payments are temporarily unavailable. Please contact the shop directly."
+
+    # If we got a checkout URL, redirect immediately
+    if checkout_url:
+        return redirect(checkout_url)
+
+    # Otherwise show an info page
+    context = {
+        'invoice': invoice,
+        'error_msg': error_msg or "Online payments are not yet available for this shop. Please contact them directly to arrange payment.",
+        'company_name': tenant.name if tenant else 'RS Systems',
+        'company_phone': tenant.business_phone if tenant else '',
+    }
+    return render(request, 'billing/public_pay_unavailable.html', context)
+
+
 def payment_complete(request):
     """Landing page after successful Stripe checkout."""
     session_id = request.GET.get('session')

--- a/templates/billing/public_pay_unavailable.html
+++ b/templates/billing/public_pay_unavailable.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Pay Invoice — {{ company_name }}</title>
+    <style>
+        body { margin: 0; padding: 0; background: #f3f4f6; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+        .container { max-width: 500px; margin: 60px auto; padding: 40px; background: white; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); text-align: center; }
+        h1 { color: #1e40af; font-size: 24px; margin: 0 0 8px; }
+        .invoice-num { color: #6b7280; font-size: 14px; margin-bottom: 24px; }
+        .amount { font-size: 36px; font-weight: 700; color: #111827; margin: 16px 0; }
+        .message { color: #6b7280; font-size: 15px; line-height: 1.6; margin: 20px 0; }
+        .contact { margin-top: 24px; padding: 16px; background: #f9fafb; border-radius: 8px; }
+        .contact p { margin: 4px 0; font-size: 14px; color: #374151; }
+        .contact a { color: #2563eb; text-decoration: none; font-weight: 600; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>{{ company_name }}</h1>
+        <p class="invoice-num">Invoice #{{ invoice.invoice_number }}</p>
+        <p class="amount">${{ invoice.amount_due|floatformat:2 }}</p>
+        <p class="message">{{ error_msg }}</p>
+        {% if company_phone %}
+        <div class="contact">
+            <p><strong>Contact:</strong></p>
+            <p><a href="tel:{{ company_phone }}">{{ company_phone }}</a></p>
+        </div>
+        {% endif %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
**Pay Invoice** button in emails now links to `/pay/<id>/<token>/` — HMAC-token secured, no login required.

- Auto-redirects to Stripe Checkout if Connect is active
- Shows branded fallback page with contact info if not  
- Overdue reminders also include pay link
- Both 'Pay Invoice' and 'View Invoice Online' use public URL