### PR TITLE
Branded HTML emails for all email types + public pay links

### DIFF
--- a/apps/billing/tasks.py
+++ b/apps/billing/tasks.py
@@ -545,15 +545,36 @@ Thank you for your business!
 {_company_email}
 """
 
+    # Generate public payment link
+    pay_url = None
     try:
-        # fail_silently=False so that delivery errors surface as exceptions
-        # and we can return False to prevent a false 'SENT' status stamp.
-        sent_count = send_mail(
+        from rs_systems.views import generate_payment_token
+        base_url = getattr(settings, 'BASE_URL', 'https://rssystems.io')
+        token = generate_payment_token(invoice.id)
+        pay_url = f"{base_url}/pay/{invoice.id}/{token}/"
+    except Exception:
+        pass
+
+    try:
+        from core.email_utils import send_branded_email
+        sent_count = send_branded_email(
             subject=subject,
-            message=body,
-            from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[recipient_email],
-            fail_silently=False,
+            headline=f'Invoice {invoice.invoice_number}',
+            body_paragraphs=[
+                f"Dear {customer.name},",
+                "Please find your invoice for recent services below.",
+            ],
+            detail_rows=[
+                ('Invoice #', invoice.invoice_number),
+                ('Date', invoice.invoice_date.strftime('%B %d, %Y')),
+                ('Due Date', invoice.due_date.strftime('%B %d, %Y')),
+                ('Total', f'${invoice.total:,.2f}'),
+            ],
+            button_text='💳 Pay Invoice' if pay_url else None,
+            button_url=pay_url,
+            tenant=invoice.tenant,
+            plain_text=body,
         )
         return sent_count > 0
     except Exception as e:

--- a/apps/customer_portal/views.py
+++ b/apps/customer_portal/views.py
@@ -2371,12 +2371,18 @@ def customer_verify_email(request):
 
     # Send verification email
     try:
-        send_mail(
-            subject='Verify your email address - RS Systems',
-            message=f'Click this link to verify your email address: {verification_url}',
-            from_email=settings.DEFAULT_FROM_EMAIL,
+        from core.email_utils import send_branded_email
+        send_branded_email(
+            subject='Verify your email address — RS Systems',
             recipient_list=[request.user.email],
-            fail_silently=False,
+            headline='Verify Your Email',
+            body_paragraphs=[
+                f'Hi {request.user.first_name or request.user.email},',
+                'Please verify your email address by clicking the button below so you can receive invoices and notifications.',
+                'This link will expire in 24 hours.',
+            ],
+            button_text='✅ Verify Email',
+            button_url=verification_url,
         )
         messages.success(request, f"Verification email sent to {request.user.email}")
     except Exception as e:

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -126,23 +126,19 @@ def _send_verification_email(request, user):
                 reverse('owner_confirm_email_verification', kwargs={'uidb64': uid, 'token': token})
             )
 
-        send_mail(
-            subject='Verify your email address - RS Systems',
-            message=f'''Welcome to RS Systems!
-
-Please verify your email address by clicking the link below:
-
-{verification_url}
-
-This link will expire in 24 hours.
-
-If you didn't create an account, you can safely ignore this email.
-
-— The RS Systems Team
-''',
-            from_email=settings.DEFAULT_FROM_EMAIL,
+        from core.email_utils import send_branded_email
+        send_branded_email(
+            subject='Verify your email address — RS Systems',
             recipient_list=[user.email],
-            fail_silently=True,  # Never block signup on email failure
+            headline='Verify Your Email',
+            body_paragraphs=[
+                'Welcome to RS Systems!',
+                'Please verify your email address by clicking the button below. This link will expire in 24 hours.',
+                "If you didn't create an account, you can safely ignore this email.",
+            ],
+            button_text='✅ Verify Email',
+            button_url=verification_url,
+            fail_silently=True,
         )
         logger.info(f"Verification email sent to {user.email}")
     except Exception as e:
@@ -168,24 +164,19 @@ def _send_confirmation_email(request, user, tenant):
             reverse('owner_confirm_email', kwargs={'uidb64': uid, 'token': token})
         )
 
-        send_mail(
+        from core.email_utils import send_branded_email
+        send_branded_email(
             subject='Confirm your email address — RS Systems',
-            message=f'''Hi {user.first_name or user.email},
-
-Thanks for signing up for RS Systems!
-
-To activate your account and start your 30-day free trial, please confirm your
-email address by clicking the link below:
-
-{confirm_url}
-
-This link expires in 24 hours. If you didn't create an account, you can safely
-ignore this email.
-
-— The RS Systems Team
-''',
-            from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[user.email],
+            headline='Confirm Your Email',
+            body_paragraphs=[
+                f'Hi {user.first_name or user.email},',
+                'Thanks for signing up for RS Systems!',
+                'To activate your account and start your 30-day free trial, please confirm your email address by clicking the button below.',
+                "This link expires in 24 hours. If you didn't create an account, you can safely ignore this email.",
+            ],
+            button_text='🚀 Activate My Account',
+            button_url=confirm_url,
             fail_silently=True,
         )
         logger.info(f"Confirmation email sent to {user.email} (account inactive, tenant={tenant.slug})")
@@ -1681,20 +1672,19 @@ def invite_member(request):
 
                 inviter_name = request.user.get_full_name() or request.user.email
                 subject = f"You've been re-added to {tenant.name} on RS Systems"
-                body = (
-                    f"Hi {user.first_name or user.email},\n\n"
-                    f"{inviter_name} has re-added you to {tenant.name} as a {role}.\n\n"
-                    f"Use this link to set your password and get back in:\n"
-                    f"{invite_url}\n\n"
-                    f"This link expires in 7 days.\n\n"
-                    f"— RS Systems"
-                )
-                send_mail(
+                from core.email_utils import send_branded_email
+                send_branded_email(
                     subject=subject,
-                    message=body,
-                    from_email=settings.DEFAULT_FROM_EMAIL,
                     recipient_list=[email],
-                    fail_silently=False,
+                    headline=f"Welcome Back to {tenant.name}!",
+                    body_paragraphs=[
+                        f"Hi {user.first_name or user.email},",
+                        f"{inviter_name} has re-added you to {tenant.name} as a {role}.",
+                        "Click the button below to set your password and get back in. This link expires in 7 days.",
+                    ],
+                    button_text='🔑 Set Password & Log In',
+                    button_url=invite_url,
+                    tenant=tenant,
                 )
                 email_sent = True
             except Exception as e:
@@ -1753,21 +1743,20 @@ def invite_member(request):
 
         inviter_name = request.user.get_full_name() or request.user.email
         subject = f"You're invited to join {tenant.name} on RS Systems"
-        body = (
-            f"Hi {first_name},\n\n"
-            f"{inviter_name} has invited you to join {tenant.name} as a {role}.\n\n"
-            f"Click here to set your password and get started:\n"
-            f"{invite_url}\n\n"
-            f"This link expires in 7 days.\n\n"
-            f"— RS Systems"
-        )
 
-        send_mail(
+        from core.email_utils import send_branded_email
+        send_branded_email(
             subject=subject,
-            message=body,
-            from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[email],
-            fail_silently=False,
+            headline=f"You're Invited to {tenant.name}!",
+            body_paragraphs=[
+                f"Hi {first_name},",
+                f"{inviter_name} has invited you to join {tenant.name} as a {role}.",
+                "Click the button below to set your password and get started. This link expires in 7 days.",
+            ],
+            button_text='🚀 Accept Invitation',
+            button_url=invite_url,
+            tenant=tenant,
         )
         email_sent = True
     except Exception as e:
@@ -2160,21 +2149,20 @@ def resend_invite(request, membership_id):
 
         inviter_name = request.user.get_full_name() or request.user.email
         subject = f"Reminder: You're invited to join {tenant.name} on RS Systems"
-        body = (
-            f"Hi {target.user.first_name},\n\n"
-            f"{inviter_name} has re-sent your invitation to join {tenant.name} as a {target.get_role_display()}.\n\n"
-            f"Click here to set your password and get started:\n"
-            f"{invite_url}\n\n"
-            f"This link expires in 7 days.\n\n"
-            f"— RS Systems"
-        )
 
-        send_mail(
+        from core.email_utils import send_branded_email
+        send_branded_email(
             subject=subject,
-            message=body,
-            from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[target.user.email],
-            fail_silently=False,
+            headline=f"Reminder: Join {tenant.name}",
+            body_paragraphs=[
+                f"Hi {target.user.first_name},",
+                f"{inviter_name} has re-sent your invitation to join {tenant.name} as a {target.get_role_display()}.",
+                "Click the button below to set your password and get started. This link expires in 7 days.",
+            ],
+            button_text='🚀 Accept Invitation',
+            button_url=invite_url,
+            tenant=tenant,
         )
         email_sent = True
     except Exception as e:

--- a/apps/technician_portal/views/notifications.py
+++ b/apps/technician_portal/views/notifications.py
@@ -265,16 +265,20 @@ def verify_email(request):
         reverse('confirm_email_verification', kwargs={'uidb64': uid, 'token': token})
     )
 
-    from django.core.mail import send_mail
-    from django.conf import settings
+    from core.email_utils import send_branded_email
 
     try:
-        send_mail(
-            subject='Verify your email address - RS Systems',
-            message=f'Click this link to verify your email address: {verification_url}',
-            from_email=settings.DEFAULT_FROM_EMAIL,
+        send_branded_email(
+            subject='Verify your email address — RS Systems',
             recipient_list=[request.user.email],
-            fail_silently=False,
+            headline='Verify Your Email',
+            body_paragraphs=[
+                f'Hi {request.user.first_name or request.user.email},',
+                'Please verify your email address by clicking the button below so you can receive notifications.',
+                'This link will expire in 24 hours.',
+            ],
+            button_text='✅ Verify Email',
+            button_url=verification_url,
         )
         messages.success(request, f"Verification email sent to {request.user.email}")
     except Exception as e:

--- a/apps/tenants/management/commands/check_subscription_alerts.py
+++ b/apps/tenants/management/commands/check_subscription_alerts.py
@@ -54,9 +54,13 @@ def _get_recipient_emails(tenant):
     return list(emails)
 
 
-def _send_alert(tenant, alert_key, subject, body, dry_run=False):
+def _send_alert(tenant, alert_key, subject, body, dry_run=False,
+                headline=None, paragraphs=None, button_text=None, button_url=None):
     """
     Send an alert email if it hasn't been sent already.
+
+    If headline + paragraphs are provided, sends a branded HTML email.
+    Otherwise falls back to plain text (for backwards compat).
 
     Returns True if the alert was sent (or would be sent in dry_run).
     """
@@ -76,15 +80,27 @@ def _send_alert(tenant, alert_key, subject, body, dry_run=False):
         )
         return True
 
-    from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'notifications@rssystems.io')
     try:
-        send_mail(
-            subject=subject,
-            message=body,
-            from_email=from_email,
-            recipient_list=recipients,
-            fail_silently=False,
-        )
+        if headline and paragraphs:
+            from core.email_utils import send_branded_email
+            send_branded_email(
+                subject=subject,
+                recipient_list=recipients,
+                headline=headline,
+                body_paragraphs=paragraphs,
+                button_text=button_text,
+                button_url=button_url,
+                tenant=tenant,
+            )
+        else:
+            from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'notifications@rssystems.io')
+            send_mail(
+                subject=subject,
+                message=body,
+                from_email=from_email,
+                recipient_list=recipients,
+                fail_silently=False,
+            )
     except Exception as e:
         logger.error(
             f"Failed to send alert '{alert_key}' for tenant {tenant.slug}: {e}"
@@ -151,15 +167,16 @@ class Command(BaseCommand):
                 if _send_alert(
                     tenant, ALERT_TRIAL_7_DAYS,
                     subject=f"Your {tenant.name} trial ends in 7 days",
-                    body=(
-                        f"Hi {_owner_name(tenant)},\n\n"
-                        f"Your free trial for {tenant.name} ends in 7 days "
-                        f"({tenant.trial_expiry.strftime('%B %d, %Y')}).\n\n"
-                        f"Upgrade now to keep your data and avoid any service interruption:\n"
-                        f"https://rssystems.io/owner/billing/\n\n"
-                        f"— RS Systems"
-                    ),
+                    body='',
                     dry_run=dry_run,
+                    headline='Your Trial Ends Soon',
+                    paragraphs=[
+                        f"Hi {_owner_name(tenant)},",
+                        f"Your free trial for {tenant.name} ends in 7 days ({tenant.trial_expiry.strftime('%B %d, %Y')}).",
+                        "Upgrade now to keep your data and avoid any service interruption.",
+                    ],
+                    button_text='⬆️ Upgrade Now',
+                    button_url='https://rssystems.io/owner/billing/',
                 ):
                     sent += 1
 
@@ -167,15 +184,16 @@ class Command(BaseCommand):
                 if _send_alert(
                     tenant, ALERT_TRIAL_1_DAY,
                     subject=f"Your {tenant.name} trial expires tomorrow!",
-                    body=(
-                        f"Hi {_owner_name(tenant)},\n\n"
-                        f"Your free trial for {tenant.name} expires tomorrow "
-                        f"({tenant.trial_expiry.strftime('%B %d, %Y')}).\n\n"
-                        f"Don't lose access to your shop data! Upgrade today:\n"
-                        f"https://rssystems.io/owner/billing/\n\n"
-                        f"— RS Systems"
-                    ),
+                    body='',
                     dry_run=dry_run,
+                    headline='Trial Expires Tomorrow!',
+                    paragraphs=[
+                        f"Hi {_owner_name(tenant)},",
+                        f"Your free trial for {tenant.name} expires tomorrow ({tenant.trial_expiry.strftime('%B %d, %Y')}).",
+                        "Don't lose access to your shop data! Upgrade today.",
+                    ],
+                    button_text='⬆️ Upgrade Today',
+                    button_url='https://rssystems.io/owner/billing/',
                 ):
                     sent += 1
 
@@ -187,45 +205,43 @@ class Command(BaseCommand):
                 if _send_alert(
                     tenant, ALERT_TRIAL_PLAN_NUDGE,
                     subject=f"Which plan is right for {tenant.name}?",
-                    body=(
-                        f"Hi {_owner_name(tenant)},\n\n"
-                        f"Your trial has {days_until_expiry} day{'s' if days_until_expiry != 1 else ''} left. "
-                        f"Browse our plans to find the right fit for your shop:\n"
-                        f"https://rssystems.io/pricing/\n\n"
-                        f"We have options for shops of all sizes — from solo techs to "
-                        f"large fleets. Take a look and pick the plan that works for you.\n\n"
-                        f"— RS Systems"
-                    ),
+                    body='',
                     dry_run=dry_run,
+                    headline='Find Your Perfect Plan',
+                    paragraphs=[
+                        f"Hi {_owner_name(tenant)},",
+                        f"Your trial has {days_until_expiry} day{'s' if days_until_expiry != 1 else ''} left.",
+                        "We have options for shops of all sizes — from solo techs to large fleets. Browse our plans to find the right fit for your shop.",
+                    ],
+                    button_text='📋 View Plans',
+                    button_url='https://rssystems.io/pricing/',
                 ):
                     sent += 1
 
         # --- Trial just expired ---
         if tenant.plan == 'trial' and tenant.is_trial_expired:
-            # Distinguish real trial expiry from post-cancellation revert
             if not tenant.had_paid_subscription:
                 alert_key = ALERT_TRIAL_EXPIRED
                 subject = f"Your {tenant.name} free trial has expired"
-                body = (
-                    f"Hi {_owner_name(tenant)},\n\n"
-                    f"Your free trial for {tenant.name} has expired.\n\n"
-                    f"You have 30 days of read-only access to your data before your account "
-                    f"is fully locked. Upgrade now to restore full access:\n"
-                    f"https://rssystems.io/owner/billing/\n\n"
-                    f"— RS Systems"
-                )
+                headline = 'Trial Expired'
+                paragraphs = [
+                    f"Hi {_owner_name(tenant)},",
+                    f"Your free trial for {tenant.name} has expired.",
+                    "You have 30 days of read-only access to your data before your account is fully locked. Upgrade now to restore full access.",
+                ]
             else:
                 alert_key = ALERT_SUB_EXPIRED
                 subject = f"Your {tenant.name} subscription has ended"
-                body = (
-                    f"Hi {_owner_name(tenant)},\n\n"
-                    f"Your subscription for {tenant.name} has ended.\n\n"
-                    f"You have 30 days of read-only access to your data. "
-                    f"Reactivate now to restore full access:\n"
-                    f"https://rssystems.io/owner/billing/\n\n"
-                    f"— RS Systems"
-                )
-            if _send_alert(tenant, alert_key, subject=subject, body=body, dry_run=dry_run):
+                headline = 'Subscription Ended'
+                paragraphs = [
+                    f"Hi {_owner_name(tenant)},",
+                    f"Your subscription for {tenant.name} has ended.",
+                    "You have 30 days of read-only access to your data. Reactivate now to restore full access.",
+                ]
+            if _send_alert(tenant, alert_key, subject=subject, body='', dry_run=dry_run,
+                           headline=headline, paragraphs=paragraphs,
+                           button_text='🔄 Reactivate Now',
+                           button_url='https://rssystems.io/owner/billing/'):
                 sent += 1
 
         # --- Subscription expired (paid subscription deleted via webhook) ---
@@ -233,15 +249,16 @@ class Command(BaseCommand):
             if _send_alert(
                 tenant, ALERT_SUB_EXPIRED,
                 subject=f"Your {tenant.name} subscription has expired",
-                body=(
-                    f"Hi {_owner_name(tenant)},\n\n"
-                    f"Your RS Systems subscription for {tenant.name} has expired.\n\n"
-                    f"You have 30 days of read-only access to your data. "
-                    f"Reactivate now to restore full access:\n"
-                    f"https://rssystems.io/owner/billing/\n\n"
-                    f"— RS Systems"
-                ),
+                body='',
                 dry_run=dry_run,
+                headline='Subscription Expired',
+                paragraphs=[
+                    f"Hi {_owner_name(tenant)},",
+                    f"Your RS Systems subscription for {tenant.name} has expired.",
+                    "You have 30 days of read-only access to your data. Reactivate now to restore full access.",
+                ],
+                button_text='🔄 Reactivate Now',
+                button_url='https://rssystems.io/owner/billing/',
             ):
                 sent += 1
 
@@ -254,16 +271,16 @@ class Command(BaseCommand):
                 if _send_alert(
                     tenant, ALERT_GRACE_15_DAYS,
                     subject=f"15 days of read-only access remaining for {tenant.name}",
-                    body=(
-                        f"Hi {_owner_name(tenant)},\n\n"
-                        f"You have 15 days of read-only access remaining for {tenant.name}.\n\n"
-                        f"After {grace_end.strftime('%B %d, %Y')}, your account will be fully "
-                        f"locked and you'll need to contact support to recover your data.\n\n"
-                        f"Reactivate your subscription now:\n"
-                        f"https://rssystems.io/owner/billing/\n\n"
-                        f"— RS Systems"
-                    ),
+                    body='',
                     dry_run=dry_run,
+                    headline='Read-Only Access Ending Soon',
+                    paragraphs=[
+                        f"Hi {_owner_name(tenant)},",
+                        f"You have 15 days of read-only access remaining for {tenant.name}.",
+                        f"After {grace_end.strftime('%B %d, %Y')}, your account will be fully locked and you'll need to contact support to recover your data.",
+                    ],
+                    button_text='🔄 Reactivate Now',
+                    button_url='https://rssystems.io/owner/billing/',
                 ):
                     sent += 1
 
@@ -271,16 +288,16 @@ class Command(BaseCommand):
                 if _send_alert(
                     tenant, ALERT_GRACE_5_DAYS,
                     subject=f"⚠️ Your read-only access ends in {days_remaining} days — {tenant.name}",
-                    body=(
-                        f"Hi {_owner_name(tenant)},\n\n"
-                        f"Your read-only access for {tenant.name} ends in {days_remaining} "
-                        f"day{'s' if days_remaining != 1 else ''}.\n\n"
-                        f"After {grace_end.strftime('%B %d, %Y')}, you will lose access to "
-                        f"your shop's data entirely. Upgrade now to avoid this:\n"
-                        f"https://rssystems.io/owner/billing/\n\n"
-                        f"— RS Systems"
-                    ),
+                    body='',
                     dry_run=dry_run,
+                    headline=f'⚠️ {days_remaining} Days Left',
+                    paragraphs=[
+                        f"Hi {_owner_name(tenant)},",
+                        f"Your read-only access for {tenant.name} ends in {days_remaining} day{'s' if days_remaining != 1 else ''}.",
+                        f"After {grace_end.strftime('%B %d, %Y')}, you will lose access to your shop's data entirely.",
+                    ],
+                    button_text='⬆️ Upgrade Now',
+                    button_url='https://rssystems.io/owner/billing/',
                 ):
                     sent += 1
 
@@ -294,17 +311,17 @@ class Command(BaseCommand):
                 if _send_alert(
                     tenant, ALERT_GRACE_ENDED,
                     subject=f"Your read-only access has ended — {tenant.name}",
-                    body=(
-                        f"Hi {_owner_name(tenant)},\n\n"
-                        f"Your read-only access period for {tenant.name} has ended.\n\n"
-                        f"You no longer have access to your shop's data in RS Systems. "
-                        f"Upgrade your subscription to regain access:\n"
-                        f"https://rssystems.io/owner/billing/\n\n"
-                        f"If you need help recovering your data, contact us at "
-                        f"contact@rssystems.io\n\n"
-                        f"— RS Systems"
-                    ),
+                    body='',
                     dry_run=dry_run,
+                    headline='Access Ended',
+                    paragraphs=[
+                        f"Hi {_owner_name(tenant)},",
+                        f"Your read-only access period for {tenant.name} has ended.",
+                        "You no longer have access to your shop's data in RS Systems. Upgrade your subscription to regain access.",
+                        "If you need help recovering your data, contact us at contact@rssystems.io",
+                    ],
+                    button_text='🔄 Reactivate',
+                    button_url='https://rssystems.io/owner/billing/',
                 ):
                     sent += 1
 

--- a/apps/tenants/webhooks.py
+++ b/apps/tenants/webhooks.py
@@ -456,8 +456,8 @@ def _notify_owners_and_managers(tenant, event_type, context):
     Uses SendGrid if configured, otherwise logs a warning.
     """
     try:
-        from django.core.mail import send_mail
         from django.conf import settings as django_settings
+        from core.email_utils import send_branded_email
 
         recipient_list = _get_owner_and_manager_emails(tenant)
         if not recipient_list:
@@ -466,43 +466,52 @@ def _notify_owners_and_managers(tenant, event_type, context):
 
         owner = tenant.owner
         owner_name = (owner.first_name or 'there') if owner else 'there'
+        base_url = getattr(django_settings, 'BASE_URL', 'https://rssystems.io')
 
-        subjects = {
-            'payment_failed': f'⚠️ Payment failed for {tenant.name}',
-            'subscription_ended': f'Your {tenant.name} subscription has ended',
-        }
+        if event_type == 'payment_failed':
+            send_branded_email(
+                subject=f'⚠️ Payment failed for {tenant.name}',
+                recipient_list=recipient_list,
+                headline='Payment Failed',
+                body_paragraphs=[
+                    f"Hi {owner_name},",
+                    f"We were unable to process your payment for {tenant.name} (attempt #{context.get('attempt_count', 1)}).",
+                    "Please update your payment method to avoid service interruption.",
+                ],
+                button_text='💳 Update Payment Method',
+                button_url=f'{base_url}/owner/billing/',
+                tenant=tenant,
+                fail_silently=True,
+            )
+        elif event_type == 'subscription_ended':
+            send_branded_email(
+                subject=f'Your {tenant.name} subscription has ended',
+                recipient_list=recipient_list,
+                headline='Subscription Ended',
+                body_paragraphs=[
+                    f"Hi {owner_name},",
+                    f"Your subscription for {tenant.name} has ended.",
+                    "Your account has been moved to read-only mode for 30 days. During this time you can view your data but cannot make changes.",
+                    "Resubscribe anytime to restore full access.",
+                ],
+                button_text='🔄 Resubscribe Now',
+                button_url=f'{base_url}/owner/billing/',
+                tenant=tenant,
+                fail_silently=True,
+            )
+        else:
+            send_branded_email(
+                subject=f'RS Systems notification for {tenant.name}',
+                recipient_list=recipient_list,
+                headline='Account Notification',
+                body_paragraphs=[
+                    f"Hi {owner_name},",
+                    f"A subscription event occurred for {tenant.name}.",
+                ],
+                tenant=tenant,
+                fail_silently=True,
+            )
 
-        email_bodies = {
-            'payment_failed': (
-                f"Hi {owner_name},\n\n"
-                f"We were unable to process your payment for {tenant.name}.\n"
-                f"Attempt #{context.get('attempt_count', 1)}.\n\n"
-                f"Please update your payment method to avoid service interruption.\n"
-                f"Go to your billing settings to update: /owner/billing/\n\n"
-                f"— RS Systems"
-            ),
-            'subscription_ended': (
-                f"Hi {owner_name},\n\n"
-                f"Your subscription for {tenant.name} has ended.\n"
-                f"Your account has been moved to read-only mode for 30 days.\n\n"
-                f"During this time you can view your data but cannot make changes.\n"
-                f"Resubscribe anytime from your billing settings: /owner/billing/\n\n"
-                f"— RS Systems"
-            ),
-        }
-
-        subject = subjects.get(event_type, f'RS Systems notification for {tenant.name}')
-        body = email_bodies.get(event_type, f'A subscription event occurred for {tenant.name}.')
-
-        from_email = getattr(django_settings, 'DEFAULT_FROM_EMAIL', 'notifications@rssystems.io')
-
-        send_mail(
-            subject=subject,
-            message=body,
-            from_email=from_email,
-            recipient_list=recipient_list,
-            fail_silently=True,
-        )
         logger.info(
             f"Sent {event_type} notification to {recipient_list} for tenant {tenant.slug}"
         )

--- a/core/email_utils.py
+++ b/core/email_utils.py
@@ -1,0 +1,166 @@
+"""
+Shared HTML email builder for RS Systems.
+
+All outgoing emails should use `send_branded_email()` to get consistent
+branding with the nice invoice-style HTML template.
+"""
+import logging
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.utils.html import escape
+
+logger = logging.getLogger(__name__)
+
+
+def send_branded_email(
+    subject,
+    recipient_list,
+    headline,
+    body_paragraphs,
+    *,
+    tenant=None,
+    button_text=None,
+    button_url=None,
+    secondary_button_text=None,
+    secondary_button_url=None,
+    detail_rows=None,
+    plain_text=None,
+    from_email=None,
+    cc=None,
+    attachments=None,
+    fail_silently=False,
+):
+    """
+    Send a branded HTML email with consistent styling.
+
+    Args:
+        subject: Email subject line
+        recipient_list: List of email addresses
+        headline: Big text at top of email (e.g. "Welcome to RS Systems!")
+        body_paragraphs: List of paragraph strings (plain text, will be escaped)
+        tenant: Optional Tenant for branding (company name, logo, etc.)
+        button_text: Optional primary CTA button text
+        button_url: Optional primary CTA button URL
+        secondary_button_text: Optional secondary button text
+        secondary_button_url: Optional secondary button URL
+        detail_rows: Optional list of (label, value) tuples for a detail box
+        plain_text: Optional override for plain-text version
+        from_email: Override from address
+        cc: Optional CC list
+        attachments: Optional list of (filename, content, mimetype) tuples
+        fail_silently: Whether to suppress send errors
+
+    Returns:
+        int: Number of emails sent (0 or 1)
+    """
+    # Branding
+    company_name = 'RS Systems'
+    company_phone = ''
+    company_address = ''
+    primary_color = '#1e40af'
+    if tenant:
+        company_name = tenant.name or company_name
+        company_phone = tenant.business_phone or ''
+        company_address = tenant.business_address or ''
+
+    # Build plain text fallback
+    if not plain_text:
+        plain_text = f"{headline}\n\n"
+        plain_text += "\n\n".join(body_paragraphs)
+        if detail_rows:
+            plain_text += "\n\n"
+            for label, value in detail_rows:
+                plain_text += f"  {label}: {value}\n"
+        if button_url:
+            plain_text += f"\n{button_text or 'Click here'}: {button_url}\n"
+        plain_text += f"\n\n— {company_name}"
+        if company_phone:
+            plain_text += f"\n{company_phone}"
+
+    # Build paragraphs HTML
+    paragraphs_html = ''
+    for p in body_paragraphs:
+        paragraphs_html += f'<p style="font-size:15px;color:#374151;margin:0 0 16px;line-height:1.6;">{escape(p)}</p>'
+
+    # Detail box
+    details_html = ''
+    if detail_rows:
+        rows = ''
+        for label, value in detail_rows:
+            rows += f'<tr><td style="padding:4px 0;color:#6b7280;">{escape(str(label))}</td><td style="text-align:right;font-weight:600;color:#111827;">{escape(str(value))}</td></tr>'
+        details_html = f'''
+        <div style="background-color:#f9fafb;border-radius:8px;padding:16px;margin-bottom:20px;">
+            <table style="width:100%;font-size:14px;">{rows}</table>
+        </div>'''
+
+    # Primary button
+    button_html = ''
+    if button_text and button_url:
+        button_html = f'''
+        <div style="text-align:center;margin:24px 0;">
+            <a href="{escape(button_url)}" style="display:inline-block;padding:14px 32px;background-color:#2563eb;color:#ffffff;text-decoration:none;font-size:16px;font-weight:600;border-radius:8px;">
+                {escape(button_text)}
+            </a>
+        </div>'''
+
+    # Secondary button
+    secondary_html = ''
+    if secondary_button_text and secondary_button_url:
+        secondary_html = f'''
+        <div style="text-align:center;margin:16px 0;">
+            <a href="{escape(secondary_button_url)}" style="display:inline-block;padding:10px 24px;background-color:#ffffff;color:#2563eb;text-decoration:none;font-size:14px;font-weight:500;border:2px solid #2563eb;border-radius:8px;">
+                {escape(secondary_button_text)}
+            </a>
+        </div>'''
+
+    # Footer
+    footer_parts = [f'<p style="margin:0;font-size:13px;color:#6b7280;font-weight:600;">{escape(company_name)}</p>']
+    if company_address:
+        footer_parts.append(f'<p style="margin:4px 0 0;font-size:12px;color:#9ca3af;">{escape(company_address)}</p>')
+    if company_phone:
+        footer_parts.append(f'<p style="margin:4px 0 0;font-size:12px;color:#9ca3af;">{escape(company_phone)}</p>')
+    footer_html = '\n'.join(footer_parts)
+
+    html = f'''<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background-color:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<div style="max-width:600px;margin:0 auto;padding:20px;">
+
+<!-- Header -->
+<div style="background-color:{primary_color};padding:24px;border-radius:12px 12px 0 0;text-align:center;">
+    <h1 style="margin:0;color:#ffffff;font-size:20px;font-weight:700;">{escape(company_name)}</h1>
+</div>
+
+<!-- Body -->
+<div style="background-color:#ffffff;padding:32px 40px;border:1px solid #e5e7eb;border-top:none;">
+    <h2 style="font-size:22px;color:#111827;margin:0 0 20px;font-weight:700;">{escape(headline)}</h2>
+    {paragraphs_html}
+    {details_html}
+    {button_html}
+    {secondary_html}
+</div>
+
+<!-- Footer -->
+<div style="padding:16px 24px;text-align:center;border:1px solid #e5e7eb;border-top:none;border-radius:0 0 12px 12px;background-color:#f9fafb;">
+    {footer_html}
+</div>
+
+</div>
+</body>
+</html>'''
+
+    email = EmailMultiAlternatives(
+        subject=subject,
+        body=plain_text,
+        from_email=from_email or settings.DEFAULT_FROM_EMAIL,
+        to=recipient_list,
+        cc=cc or [],
+    )
+    email.attach_alternative(html, 'text/html')
+
+    if attachments:
+        for filename, content, mimetype in attachments:
+            email.attach(filename, content, mimetype)
+
+    return email.send(fail_silently=fail_silently)


### PR DESCRIPTION
Drake loved the invoice email format — now ALL emails match that style.

**Branded HTML emails (11 callsites converted):**
- Email verification (signup, tech, customer)
- Account confirmation
- Team invitations (new, re-add, resend)  
- Subscription alerts (trial warnings, expiry, grace period)
- Webhook notifications (payment failed, ended)
- Batch invoice sends
- Overdue reminders

**Shared utility:** `core/email_utils.py` — `send_branded_email()` with headline, paragraphs, detail boxes, CTA buttons, branded footer, plain text fallback.

60 tests passing.