### PR TITLE
Fix Stripe Connect webhook — payments now recorded automatically

### DIFF
--- a/apps/billing/services/stripe_service.py
+++ b/apps/billing/services/stripe_service.py
@@ -43,6 +43,7 @@ class StripeService:
     def __init__(self):
         self.api_key = getattr(settings, 'STRIPE_SECRET_KEY', None)
         self.webhook_secret = getattr(settings, 'STRIPE_WEBHOOK_SECRET', None)
+        self.connect_webhook_secret = getattr(settings, 'STRIPE_CONNECT_WEBHOOK_SECRET', None)
         
         if STRIPE_AVAILABLE and self.api_key:
             stripe.api_key = self.api_key
@@ -252,13 +253,24 @@ class StripeService:
         if not self.webhook_secret:
             return {'success': False, 'error': 'Webhook secret not configured'}
         
-        try:
-            event = stripe.Webhook.construct_event(
-                payload, sig_header, self.webhook_secret
-            )
-        except ValueError:
-            return {'success': False, 'error': 'Invalid payload'}
-        except stripe.error.SignatureVerificationError:
+        # Try platform webhook secret first, then Connect webhook secret.
+        # Connect events arrive on the same URL but are signed with the
+        # Connect endpoint's secret.
+        event = None
+        secrets_to_try = [self.webhook_secret]
+        if self.connect_webhook_secret:
+            secrets_to_try.append(self.connect_webhook_secret)
+
+        for secret in secrets_to_try:
+            try:
+                event = stripe.Webhook.construct_event(payload, sig_header, secret)
+                break
+            except stripe.error.SignatureVerificationError:
+                continue
+            except ValueError:
+                return {'success': False, 'error': 'Invalid payload'}
+
+        if event is None:
             return {'success': False, 'error': 'Invalid signature'}
         
         event_type = event['type']

--- a/rs_systems/settings/base.py
+++ b/rs_systems/settings/base.py
@@ -199,6 +199,7 @@ else:
     STRIPE_SECRET_KEY = os.environ.get('STRIPE_SECRET_KEY', '')
 
 STRIPE_WEBHOOK_SECRET = os.environ.get('STRIPE_WEBHOOK_SECRET', '')  # Billing/invoice webhooks
+STRIPE_CONNECT_WEBHOOK_SECRET = os.environ.get('STRIPE_CONNECT_WEBHOOK_SECRET', '')  # Connect account webhooks
 STRIPE_SUBSCRIPTION_WEBHOOK_SECRET = os.environ.get('STRIPE_SUBSCRIPTION_WEBHOOK_SECRET', '')  # SaaS subscription webhooks
 STRIPE_TEST_MODE = STRIPE_MODE == 'test'
 


### PR DESCRIPTION
**Bug:** Stripe Connect payments weren't being recorded. The webhook handler only verified signatures with the platform secret, but Connect events are signed with a separate Connect webhook secret.

**Fix:**
- Added `STRIPE_CONNECT_WEBHOOK_SECRET` setting
- Webhook handler tries platform secret first, then Connect secret
- Created Connect webhook endpoint in Stripe dashboard

**Impact:** Drake's $1.10 payment on invoice 24 succeeded in Stripe but wasn't recorded in RS Systems. Retroactively recorded via API.