### PR TITLE
All emails now branded HTML — zero plain text remaining

### DIFF
--- a/apps/billing/services/reminder_service.py
+++ b/apps/billing/services/reminder_service.py
@@ -456,22 +456,26 @@ Please contact us to arrange payment or if you have any questions.
                 logger.error(f"SendGrid error: {e}")
                 # Fall through to Django email
         
-        # Fallback to Django's email backend
+        # Fallback to Django's email backend (branded HTML)
         try:
-            from django.core.mail import EmailMessage
-            
-            email = EmailMessage(
-                subject=subject,
-                body=body,
-                from_email=self.from_email,
-                to=[to_email],
-            )
-            
-            # Attach PDF if provided
+            from core.email_utils import send_branded_email
+
+            attachments = []
             if pdf_attachment and invoice:
-                email.attach(f"Invoice_{invoice.invoice_number}.pdf", pdf_attachment, 'application/pdf')
-            
-            email.send(fail_silently=False)
+                attachments.append(
+                    (f"Invoice_{invoice.invoice_number}.pdf", pdf_attachment, 'application/pdf')
+                )
+
+            tenant = getattr(invoice, 'tenant', None) if invoice else None
+            send_branded_email(
+                subject=subject,
+                recipient_list=[to_email],
+                headline=subject,
+                body_paragraphs=[body],
+                tenant=tenant,
+                attachments=attachments,
+                from_email=self.from_email,
+            )
             return True
             
         except Exception as e:

--- a/apps/billing/tasks.py
+++ b/apps/billing/tasks.py
@@ -185,12 +185,26 @@ Thank you,
 """
     
     try:
-        send_mail(
+        from core.email_utils import send_branded_email
+        send_branded_email(
             subject=subject,
-            message=body,
-            from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[recipient_email],
-            fail_silently=False,
+            headline=f'Payment Reminder — Invoice {invoice.invoice_number}',
+            body_paragraphs=[
+                f"Dear {customer.name},",
+                f"This is a friendly reminder that invoice {invoice.invoice_number} is now {days_overdue} days overdue.",
+                "If you have already sent payment, please disregard this notice.",
+            ],
+            detail_rows=[
+                ('Invoice #', invoice.invoice_number),
+                ('Invoice Date', invoice.invoice_date.strftime('%B %d, %Y')),
+                ('Due Date', invoice.due_date.strftime('%B %d, %Y')),
+                ('Amount Due', f'${invoice.amount_due:.2f}'),
+            ],
+            button_text='💳 Pay Now' if pay_url else None,
+            button_url=pay_url if pay_url else None,
+            tenant=invoice.tenant,
+            plain_text=body,
         )
         
         # Log that we sent a reminder

--- a/apps/tenants/management/commands/check_subscription_alerts.py
+++ b/apps/tenants/management/commands/check_subscription_alerts.py
@@ -93,13 +93,14 @@ def _send_alert(tenant, alert_key, subject, body, dry_run=False,
                 tenant=tenant,
             )
         else:
-            from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'notifications@rssystems.io')
-            send_mail(
+            # Fallback: wrap plain-text body in branded template
+            from core.email_utils import send_branded_email
+            send_branded_email(
                 subject=subject,
-                message=body,
-                from_email=from_email,
                 recipient_list=recipients,
-                fail_silently=False,
+                headline=subject,
+                body_paragraphs=[body] if body else ['A subscription event occurred.'],
+                tenant=tenant,
             )
     except Exception as e:
         logger.error(

--- a/apps/tenants/views.py
+++ b/apps/tenants/views.py
@@ -118,36 +118,22 @@ def _send_welcome_email(user, tenant, trial_days=30):
         return
 
     try:
-        from django.core.mail import send_mail
-        from django.conf import settings
+        from core.email_utils import send_branded_email
 
-        subject = f"Welcome to RS Systems, {user.first_name}! 🎉"
-        message = (
-            f"Hi {user.first_name},\n\n"
-            f"Welcome to RS Systems! Your shop \"{tenant.name}\" is set up and "
-            f"your 30-day free trial has started.\n\n"
-            f"YOUR TRIAL INCLUDES:\n"
-            f"  • Up to 50 repairs per month\n"
-            f"  • 2 technician seats\n"
-            f"  • 10 customer accounts\n"
-            f"  • Full invoicing & billing\n"
-            f"  • 100 MB photo storage\n\n"
-            f"QUICK START:\n"
-            f"  1. Log in and add your first customer\n"
-            f"  2. Create a repair record\n"
-            f"  3. Generate an invoice in one click\n\n"
-            f"Your trial expires in {trial_days} days. Upgrade anytime at "
-            f"/api/tenants/subscribe/ to keep your data.\n\n"
-            f"Need help? Reply to this email or visit our docs.\n\n"
-            f"— The RS Systems Team\n"
-            f"   Built for glass shops, by glass shops."
-        )
-
-        send_mail(
-            subject=subject,
-            message=message,
-            from_email=settings.DEFAULT_FROM_EMAIL,
+        send_branded_email(
+            subject=f"Welcome to RS Systems, {user.first_name}! 🎉",
             recipient_list=[user.email],
+            headline=f'Welcome to RS Systems!',
+            body_paragraphs=[
+                f"Hi {user.first_name},",
+                f'Your shop "{tenant.name}" is set up and your {trial_days}-day free trial has started.',
+                "Your trial includes up to 50 repairs/month, 2 technician seats, 10 customer accounts, full invoicing & billing, and 100 MB photo storage.",
+                "Quick start: Log in, add your first customer, create a repair record, and generate an invoice in one click.",
+                f"Your trial expires in {trial_days} days. Upgrade anytime to keep your data.",
+            ],
+            button_text='🚀 Get Started',
+            button_url='https://rssystems.io/login/',
+            tenant=tenant,
             fail_silently=True,
         )
         logger.info(f"Welcome email sent to {user.email}")


### PR DESCRIPTION
Final sweep: converted 4 remaining plain-text email callsites to branded HTML.

- Welcome email (signup) → branded with 'Get Started' CTA
- Overdue reminders → branded with 'Pay Now' button
- Reminder service fallback → branded with PDF attachments
- Subscription alert fallback → branded

**Audit result:** Every single email in RS Systems now uses either `send_branded_email()` or HTML templates extending `emails/base.html`. Zero plain-text-only emails remain.