### PR TITLE
CODE-276/277: Fix customer email 500 + inline email capture on Send Invoice

### DIFF
--- a/apps/customer_portal/views.py
+++ b/apps/customer_portal/views.py
@@ -19,7 +19,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth import login, authenticate
 from django.utils import timezone
 from django.db.models import Sum, Q, Count
-from django.db import models, transaction
+from django.db import models, transaction, IntegrityError
 from django.contrib.auth import update_session_auth_hash
 from functools import wraps
 from django.http import JsonResponse
@@ -1561,9 +1561,18 @@ def edit_company(request):
             customer.zip_code = request.POST.get('zip_code', '')
             
             try:
-                customer.save()
+                # Savepoint so a constraint violation doesn't poison the
+                # surrounding transaction before we re-render with an error.
+                with transaction.atomic():
+                    customer.save()
                 messages.success(request, "Company information updated successfully!")
                 return redirect('customer_dashboard')
+            except IntegrityError:
+                messages.error(
+                    request,
+                    "Another customer already uses that name or email. "
+                    "Please contact your shop if you believe this is an error."
+                )
             except Exception as e:
                 messages.error(request, f"Error updating company: {str(e)}")
         

--- a/apps/saas/views.py
+++ b/apps/saas/views.py
@@ -2852,6 +2852,44 @@ def owner_send_invoice(request, invoice_id):
         except Exception:
             recipient = invoice.customer.email
 
+        # Inline email capture — the send modal shows an email field when the
+        # customer has no address on file, so the owner can add one and send
+        # in a single step instead of hunting for the customer edit page.
+        submitted_email = request.POST.get('email', '').strip()
+        if submitted_email and not recipient:
+            from django.core.validators import validate_email
+            from django.core.exceptions import ValidationError as _EmailValidationError
+            from django.db import IntegrityError as _IntegrityError
+            try:
+                validate_email(submitted_email)
+            except _EmailValidationError:
+                messages.error(request, f'"{submitted_email}" is not a valid email address.')
+                return redirect('owner_invoice_detail', invoice_id=invoice.id)
+            duplicate = Customer.objects.filter(
+                tenant=tenant, email__iexact=submitted_email
+            ).exclude(pk=invoice.customer.pk).exists()
+            if duplicate:
+                messages.error(
+                    request,
+                    'Another customer already uses that email address. '
+                    'Please use a different one.'
+                )
+                return redirect('owner_invoice_detail', invoice_id=invoice.id)
+            try:
+                # Savepoint so a duplicate slipping past the check above (race)
+                # doesn't poison the surrounding transaction.
+                with transaction.atomic():
+                    invoice.customer.email = submitted_email
+                    invoice.customer.save(update_fields=['email'])
+            except _IntegrityError:
+                messages.error(
+                    request,
+                    'Another customer already uses that email address. '
+                    'Please use a different one.'
+                )
+                return redirect('owner_invoice_detail', invoice_id=invoice.id)
+            recipient = submitted_email
+
         # CODE-112: Block send entirely if no email on file
         if not recipient:
             messages.error(

--- a/apps/technician_portal/forms.py
+++ b/apps/technician_portal/forms.py
@@ -132,6 +132,34 @@ class TechnicianRegistrationForm(UserCreationForm):
             )
         return user
     
+def _clean_customer_email(form):
+    """Shared email cleaning for customer forms.
+
+    Returns None for blank input (the DB stores "no email" as NULL — the
+    unique_customer_email_per_tenant constraint only ignores NULL, so ''
+    must never be saved). Raises a friendly ValidationError when another
+    customer in the same tenant already uses the address; without this the
+    conditional unique constraint surfaces as an IntegrityError 500, since
+    Django's ModelForm validation skips constraints that have a condition.
+    """
+    email = (form.cleaned_data.get('email') or '').strip()
+    if not email:
+        return None
+    tenant = form.tenant or getattr(form.instance, 'tenant', None)
+    qs = Customer.objects.filter(email__iexact=email)
+    if tenant:
+        qs = qs.filter(tenant=tenant)
+    if form.instance.pk:
+        qs = qs.exclude(pk=form.instance.pk)
+    existing = qs.first()
+    if existing:
+        raise forms.ValidationError(
+            f'"{existing.name}" already uses this email address. '
+            'Each customer needs a unique email.'
+        )
+    return email
+
+
 class CustomerForm(forms.ModelForm):
     """Form for creating customers with optional portal invitation."""
     
@@ -235,6 +263,9 @@ class CustomerForm(forms.ModelForm):
             raise forms.ValidationError('Batch invoice day must be between 1 and 28.')
         return day
 
+    def clean_email(self):
+        return _clean_customer_email(self)
+
     def clean_phone(self):
         """Normalize phone to digits-only, accept common formats."""
         import re
@@ -293,6 +324,9 @@ class CustomerEditForm(forms.ModelForm):
         self.fields['email'].widget.attrs['placeholder'] = 'billing@company.com'
         self.fields['phone'].widget.attrs['placeholder'] = '+1 (555) 123-4567'
         self.fields['tax_exempt_certificate'].widget.attrs['placeholder'] = 'Certificate number (if exempt)'
+
+    def clean_email(self):
+        return _clean_customer_email(self)
 
 class CustomDateTimeInput(DateTimeInput):
     input_type = 'datetime-local'

--- a/apps/technician_portal/views/customers.py
+++ b/apps/technician_portal/views/customers.py
@@ -4,6 +4,7 @@ Customer management views for the technician portal.
 
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib import messages
+from django.db import IntegrityError, transaction
 from django.db.models import Q, Count
 from django.views.decorators.http import require_POST
 
@@ -495,9 +496,23 @@ def edit_customer(request, customer_id):
     if request.method == 'POST':
         form = CustomerEditForm(request.POST, instance=customer, tenant=tenant)
         if form.is_valid():
-            form.save()
-            messages.success(request, f"Customer '{customer.name}' updated successfully.")
-            return redirect('customer_detail', customer_id=customer_id)
+            try:
+                # Savepoint so a constraint violation doesn't poison the
+                # surrounding transaction before we re-render the form.
+                with transaction.atomic():
+                    form.save()
+            except IntegrityError:
+                # Safety net for races the form's clean_email check can miss —
+                # the conditional unique constraints on (tenant, email) and
+                # (tenant, name) otherwise surface as a 500.
+                form.add_error(
+                    None,
+                    'Another customer already uses that name or email. '
+                    'Please choose a different one.'
+                )
+            else:
+                messages.success(request, f"Customer '{customer.name}' updated successfully.")
+                return redirect('customer_detail', customer_id=customer_id)
     else:
         form = CustomerEditForm(instance=customer, tenant=tenant)
     

--- a/core/migrations/0021_null_blank_customer_emails.py
+++ b/core/migrations/0021_null_blank_customer_emails.py
@@ -1,0 +1,30 @@
+# Convert Customer.email == '' to NULL.
+#
+# The unique_customer_email_per_tenant constraint only exempts NULL emails
+# (condition=Q(email__isnull=False)). Customers created through forms with a
+# blank email were saved with '' — so the FIRST no-email customer per tenant
+# occupied the '' slot and every subsequent no-email customer (or edit) hit an
+# IntegrityError → production 500. Customer.save() now normalizes '' → None;
+# this migration fixes rows that already exist.
+
+from django.db import migrations
+
+
+def null_blank_emails(apps, schema_editor):
+    Customer = apps.get_model('core', 'Customer')
+    Customer.objects.filter(email='').update(email=None)
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0020_relax_phone_validation'),
+    ]
+
+    operations = [
+        migrations.RunPython(null_blank_emails, noop),
+    ]

--- a/core/models/customer.py
+++ b/core/models/customer.py
@@ -136,4 +136,9 @@ class Customer(models.Model):
         # or "Penske" is incorrect for display
         if self.name:
             self.name = self.name.strip()
+        # Store "no email" as NULL, never ''. The unique_customer_email_per_tenant
+        # constraint only ignores NULL, so a second customer saved with '' raises
+        # IntegrityError (500) even though both have "no email".
+        if self.email is not None:
+            self.email = self.email.strip() or None
         super().save(*args, **kwargs)

--- a/rs_systems/settings/base.py
+++ b/rs_systems/settings/base.py
@@ -160,15 +160,22 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 FILE_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 
 # =========================================
-# EMAIL CONFIGURATION (SendGrid)
+# EMAIL CONFIGURATION (SMTP)
 # =========================================
+# Defaults to SendGrid; overridable via env so switching providers
+# (e.g. Amazon SES: EMAIL_HOST=email-smtp.us-east-1.amazonaws.com,
+# EMAIL_HOST_USER=<SES SMTP username>, EMAIL_HOST_PASSWORD=<SES SMTP
+# password>) is an `eb setenv`, not a code deploy.
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'smtp.sendgrid.net'
-EMAIL_PORT = 587
+EMAIL_HOST = os.environ.get('EMAIL_HOST', 'smtp.sendgrid.net')
+EMAIL_PORT = int(os.environ.get('EMAIL_PORT', 587))
 EMAIL_USE_TLS = True
-EMAIL_HOST_USER = 'apikey'
-EMAIL_HOST_PASSWORD = os.environ.get('SENDGRID_API_KEY')
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', 'apikey')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD') or os.environ.get('SENDGRID_API_KEY')
+# Cap SMTP connection time — without this a slow/unreachable provider
+# hangs the web worker for the request that triggered the email.
+EMAIL_TIMEOUT = int(os.environ.get('EMAIL_TIMEOUT', 10))
 
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'notifications@rssystems.io')
 DEFAULT_FROM_NAME = os.environ.get('DEFAULT_FROM_NAME', 'RS Systems')

--- a/rs_systems/settings/development.py
+++ b/rs_systems/settings/development.py
@@ -149,7 +149,7 @@ TIME_ZONE = os.environ.get('TIME_ZONE', 'America/Chicago')
 # Set USE_REAL_EMAIL=True to actually send emails
 USE_REAL_EMAIL = os.environ.get('USE_REAL_EMAIL', 'False').lower() == 'true'
 
-if not USE_REAL_EMAIL or not os.environ.get('SENDGRID_API_KEY'):
+if not USE_REAL_EMAIL or not (os.environ.get('EMAIL_HOST_PASSWORD') or os.environ.get('SENDGRID_API_KEY')):
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
     # Emails will be printed to console instead of sent
 

--- a/templates/saas/owner_invoice_detail.html
+++ b/templates/saas/owner_invoice_detail.html
@@ -761,17 +761,29 @@ document.addEventListener('keydown', function(e) {
                 </div>
             </form>
             {% else %}
-            <div class="bg-red-50 border border-red-200 rounded-lg p-3 mb-4">
-                <p class="text-sm text-red-700">
+            <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4">
+                <p class="text-sm text-amber-800">
                     <i class="fas fa-exclamation-circle mr-1"></i>
-                    Cannot send — no email address on file for {{ invoice.customer.name }}.
-                    Add an email in the customer's settings first.
+                    No email on file for {{ invoice.customer.name }}.
+                    Enter one below — it will be saved to the customer and the invoice sent.
                 </p>
             </div>
-            <button onclick="document.getElementById('send-confirm-modal').classList.add('hidden')"
-                class="w-full px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-200 transition-colors">
-                Close
-            </button>
+            <form method="post" action="{% url 'owner_send_invoice' invoice_id=invoice.id %}">
+                {% csrf_token %}
+                <label for="send-invoice-email" class="block text-sm font-medium text-gray-700 mb-1">Customer email</label>
+                <input type="email" name="email" id="send-invoice-email" required
+                    placeholder="billing@company.com"
+                    class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm mb-4 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none">
+                <div class="flex gap-3">
+                    <button type="submit" class="flex-1 px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors">
+                        <i class="fas fa-paper-plane mr-1"></i>Save Email &amp; Send
+                    </button>
+                    <button type="button" onclick="document.getElementById('send-confirm-modal').classList.add('hidden')"
+                        class="px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-200 transition-colors">
+                        Cancel
+                    </button>
+                </div>
+            </form>
             {% endif %}
         </div>
     </div>

--- a/tests/bug_fixes/test_code276_customer_email_500_and_inline_send.py
+++ b/tests/bug_fixes/test_code276_customer_email_500_and_inline_send.py
@@ -1,0 +1,246 @@
+"""
+Regression tests for CODE-276 / CODE-277:
+
+CODE-276 — Editing a customer to add an email 500'd in production.
+  Two root causes, both from the conditional unique constraint
+  unique_customer_email_per_tenant (condition: email IS NOT NULL):
+
+    1. Forms saved "no email" as '' (empty string), not NULL. The constraint
+       only ignores NULL, so the SECOND no-email customer in a tenant raised
+       IntegrityError on save.
+    2. Django's ModelForm validation skips UniqueConstraints that have a
+       condition, so giving a customer an email already used by another
+       customer in the tenant went straight to the DB → IntegrityError → 500.
+
+  Fix: Customer.save() normalizes '' → None, customer forms clean blank
+  email to None and validate duplicates with a friendly error, and
+  edit_customer() catches IntegrityError as a safety net.
+  Migration core.0021 nulls out existing '' emails.
+
+CODE-277 — The Send Invoice modal dead-ended when the customer had no email
+  ("add an email in the customer's settings first" with no link). The modal
+  now shows an inline email field; owner_send_invoice() validates it, saves
+  it to the customer, and proceeds with the send in one step.
+"""
+
+from decimal import Decimal
+from unittest.mock import patch
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from django.utils import timezone
+from django.urls import reverse
+
+from apps.tenants.models import Tenant, TenantMembership
+from core.models import Customer
+from apps.billing.models import Invoice
+
+
+def _make_tenant(name='Email Fix Shop'):
+    owner = User.objects.create_user(
+        username=f'owner_ef_{User.objects.count()}',
+        email=f'owner_ef_{User.objects.count()}@example.com',
+        password='testpass123',
+    )
+    tenant = Tenant.objects.create(
+        name=name,
+        slug=f'email-fix-{Tenant.objects.count()}',
+        plan='trial',
+        owner=owner,
+    )
+    TenantMembership.objects.create(tenant=tenant, user=owner, role='owner')
+    return tenant, owner
+
+
+def _make_draft_invoice(tenant, customer):
+    return Invoice.objects.create(
+        tenant=tenant,
+        customer=customer,
+        invoice_number=f'INV-TEST-{Invoice.objects.count():04d}',
+        invoice_date=timezone.now().date(),
+        subtotal=Decimal('50.00'),
+        tax_amount=Decimal('4.88'),
+        total=Decimal('54.88'),
+        amount_paid=Decimal('0.00'),
+        status='DRAFT',
+    )
+
+
+class CustomerEmailNormalizationTests(TestCase):
+    """CODE-276: '' emails must be stored as NULL."""
+
+    def setUp(self):
+        self.tenant, self.owner = _make_tenant()
+
+    def test_model_save_normalizes_empty_string_to_null(self):
+        c = Customer.objects.create(tenant=self.tenant, name='eos trucking', email='')
+        c.refresh_from_db()
+        self.assertIsNone(c.email)
+
+    def test_model_save_strips_whitespace(self):
+        c = Customer.objects.create(tenant=self.tenant, name='acme', email='  ap@acme.com  ')
+        c.refresh_from_db()
+        self.assertEqual(c.email, 'ap@acme.com')
+
+    def test_two_customers_without_email_in_same_tenant(self):
+        """The original production crash: second no-email customer raised
+        IntegrityError because both rows stored email=''."""
+        Customer.objects.create(tenant=self.tenant, name='first co', email='')
+        second = Customer.objects.create(tenant=self.tenant, name='second co', email='')
+        self.assertIsNone(second.email)
+        self.assertEqual(Customer.objects.filter(tenant=self.tenant).count(), 2)
+
+
+class EditCustomerEmail500Tests(TestCase):
+    """CODE-276: edit_customer must never 500 on email conflicts."""
+
+    def setUp(self):
+        from apps.technician_portal.models import Technician
+        self.tenant, self.owner = _make_tenant()
+        Technician.objects.create(tenant=self.tenant, user=self.owner, is_active=True, is_manager=True)
+        self.client = Client()
+        self.client.force_login(self.owner)
+        session = self.client.session
+        session['tenant_id'] = self.tenant.id
+        session.save()
+
+    def _post_edit(self, customer, email, name=None):
+        return self.client.post(reverse('edit_customer', args=[customer.id]), {
+            'name': name or customer.name, 'customer_type': 'FLEET', 'email': email,
+            'phone': '', 'address': '', 'city': '', 'state': '', 'zip_code': '',
+            'primary_technician': '', 'tax_exempt_certificate': '',
+        })
+
+    def test_add_email_to_customer_without_email(self):
+        c = Customer.objects.create(tenant=self.tenant, name='eos trucking', email='')
+        resp = self._post_edit(c, 'ap@eostrucking.com')
+        self.assertEqual(resp.status_code, 302)
+        c.refresh_from_db()
+        self.assertEqual(c.email, 'ap@eostrucking.com')
+
+    def test_duplicate_email_shows_form_error_not_500(self):
+        Customer.objects.create(tenant=self.tenant, name='other co', email='shared@example.com')
+        c = Customer.objects.create(tenant=self.tenant, name='eos trucking', email='')
+        resp = self._post_edit(c, 'shared@example.com')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'already uses this email')
+        c.refresh_from_db()
+        self.assertIsNone(c.email)
+
+    def test_duplicate_email_case_insensitive(self):
+        Customer.objects.create(tenant=self.tenant, name='other co', email='shared@example.com')
+        c = Customer.objects.create(tenant=self.tenant, name='eos trucking', email='')
+        resp = self._post_edit(c, 'SHARED@EXAMPLE.COM')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'already uses this email')
+
+    def test_same_email_in_other_tenant_is_allowed(self):
+        other_tenant, _ = _make_tenant('Other Shop')
+        Customer.objects.create(tenant=other_tenant, name='their co', email='shared@example.com')
+        c = Customer.objects.create(tenant=self.tenant, name='eos trucking', email='')
+        resp = self._post_edit(c, 'shared@example.com')
+        self.assertEqual(resp.status_code, 302)
+        c.refresh_from_db()
+        self.assertEqual(c.email, 'shared@example.com')
+
+    def test_clearing_email_saves_null(self):
+        c = Customer.objects.create(tenant=self.tenant, name='eos trucking', email='old@example.com')
+        resp = self._post_edit(c, '')
+        self.assertEqual(resp.status_code, 302)
+        c.refresh_from_db()
+        self.assertIsNone(c.email)
+
+    def test_keeping_own_email_is_allowed(self):
+        c = Customer.objects.create(tenant=self.tenant, name='eos trucking', email='ap@eostrucking.com')
+        resp = self._post_edit(c, 'ap@eostrucking.com')
+        self.assertEqual(resp.status_code, 302)
+
+
+class SendInvoiceInlineEmailTests(TestCase):
+    """CODE-277: owner_send_invoice accepts an inline email for no-email customers."""
+
+    def setUp(self):
+        self.tenant, self.owner = _make_tenant()
+        self.customer = Customer.objects.create(tenant=self.tenant, name='eos trucking', email='')
+        self.invoice = _make_draft_invoice(self.tenant, self.customer)
+        self.client = Client()
+        self.client.force_login(self.owner)
+        session = self.client.session
+        session['tenant_id'] = self.tenant.id
+        session.save()
+
+    def _post_send(self, email=None, follow=True):
+        data = {}
+        if email is not None:
+            data['email'] = email
+        return self.client.post(
+            reverse('owner_send_invoice', kwargs={'invoice_id': self.invoice.id}),
+            data, follow=follow,
+        )
+
+    def test_inline_email_saved_and_invoice_sent(self):
+        with patch(
+            'apps.billing.services.invoice_email_service.InvoiceEmailService.send_invoice_email',
+            return_value=(True, 'Sent OK'),
+        ) as mock_send:
+            self._post_send('ap@eostrucking.com')
+
+        self.customer.refresh_from_db()
+        self.assertEqual(self.customer.email, 'ap@eostrucking.com')
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, 'SENT')
+        self.assertEqual(mock_send.call_args.kwargs['recipient_email'], 'ap@eostrucking.com')
+
+    def test_invalid_inline_email_rejected(self):
+        with patch(
+            'apps.billing.services.invoice_email_service.InvoiceEmailService.send_invoice_email',
+        ) as mock_send:
+            resp = self._post_send('not-an-email')
+
+        mock_send.assert_not_called()
+        self.customer.refresh_from_db()
+        self.assertIsNone(self.customer.email)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, 'DRAFT')
+        messages = [m.message for m in resp.context['messages']]
+        self.assertTrue(any('not a valid email' in m for m in messages), messages)
+
+    def test_inline_email_duplicate_of_other_customer_rejected(self):
+        Customer.objects.create(tenant=self.tenant, name='other co', email='shared@example.com')
+        with patch(
+            'apps.billing.services.invoice_email_service.InvoiceEmailService.send_invoice_email',
+        ) as mock_send:
+            resp = self._post_send('shared@example.com')
+
+        mock_send.assert_not_called()
+        self.customer.refresh_from_db()
+        self.assertIsNone(self.customer.email)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, 'DRAFT')
+        messages = [m.message for m in resp.context['messages']]
+        self.assertTrue(any('already uses that email' in m for m in messages), messages)
+
+    def test_no_email_still_blocks_send(self):
+        with patch(
+            'apps.billing.services.invoice_email_service.InvoiceEmailService.send_invoice_email',
+        ) as mock_send:
+            resp = self._post_send()
+
+        mock_send.assert_not_called()
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, 'DRAFT')
+        messages = [m.message for m in resp.context['messages']]
+        self.assertTrue(any('no email address on file' in m for m in messages), messages)
+
+    def test_inline_email_ignored_when_customer_already_has_email(self):
+        self.customer.email = 'existing@eostrucking.com'
+        self.customer.save()
+        with patch(
+            'apps.billing.services.invoice_email_service.InvoiceEmailService.send_invoice_email',
+            return_value=(True, 'Sent OK'),
+        ) as mock_send:
+            self._post_send('other@example.com')
+
+        # Existing email on file wins — the inline field only fills a gap.
+        self.assertEqual(mock_send.call_args.kwargs['recipient_email'], 'existing@eostrucking.com')
+        self.customer.refresh_from_db()
+        self.assertEqual(self.customer.email, 'existing@eostrucking.com')


### PR DESCRIPTION
## Summary

**CODE-276 — Production 500 when adding an email to a customer.** Two root causes, both from the conditional unique constraint on `(tenant, email)`:
- Customer forms saved "no email" as `''` (empty string), not NULL. The constraint only exempts NULL, so the second no-email customer per tenant — and edits to them — raised `IntegrityError` → 500.
- Django's ModelForm validation skips `UniqueConstraint`s that have a `condition`, so giving a customer an email already used by another customer in the tenant went straight to the DB → `IntegrityError` → 500.

Fixes:
- `Customer.save()` normalizes `''`/whitespace email to NULL
- `CustomerForm`/`CustomerEditForm` clean blank email to None and show a friendly duplicate-email error (same email in a *different* tenant remains allowed)
- `edit_customer` / `edit_company` wrap saves in a savepoint and catch `IntegrityError` as a race safety net
- Migration `core.0021` nulls out existing `''` emails in production

**CODE-277 — Send Invoice modal dead-ended with no email on file** ("add an email in the customer's settings first", no link). The modal now shows an inline email field; `owner_send_invoice` validates it, saves it to the customer, and sends in one step.

**Email config hardening:**
- `EMAIL_TIMEOUT=10` — emails send synchronously in request handlers; a hung SMTP provider previously hung the web worker
- SMTP host/port/user/password now env-driven with SendGrid defaults, so moving to Amazon SES is an `eb setenv`, not a code deploy

## Testing

- 14 new regression tests in `tests/bug_fixes/test_code276_customer_email_500_and_inline_send.py` — all passing
- `tests.test_primary_contact` + `tests.test_e2e_today` smoke suites pass
- The 17 failures in `tests.bug_fixes` (test_ux_fixes, code098, code139, code060) are pre-existing on `main` at e315add0 — verified identical count with this branch's changes stashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)